### PR TITLE
Add error count

### DIFF
--- a/eadator/eadator.py
+++ b/eadator/eadator.py
@@ -16,14 +16,20 @@ def main(argv=None):
                         type=argparse.FileType('r'))
     parser.add_argument('--dtd', required=False, )
     parser.add_argument('--xsd', required=False, )
+    parser.add_argument('--count', action='store_true' )
 
     if argv is None:
         argv = parser.parse_args()
 
-    message, valid = validate(argv.eadfile[0], argv.dtd, argv.xsd)
+    message, valid, error_count = validate(argv.eadfile[0], argv.dtd, argv.xsd)
 
     if not valid:
         pp(message)
+
+    if argv.count:
+        print "Error count : %d" % error_count
+
+    if not valid:
         exit(1)
     
 def validate(eadfile, dtd=None, xsd=None):
@@ -48,12 +54,14 @@ def validate(eadfile, dtd=None, xsd=None):
         validator = etree.XMLSchema(etree.parse(xsd))
 
     message = None
+    error_count = 0
     valid = validator.validate(eadfile)
 
     if not valid:
         message = validator.error_log
+        error_count = len(message)
 
-    return message, valid
+    return message, valid, error_count
     
 
 # main() idiom for importing into REPL for debugging 

--- a/eadator/eadator.py
+++ b/eadator/eadator.py
@@ -27,7 +27,7 @@ def main(argv=None):
         pp(message)
 
     if argv.count:
-        print "Error count : %d" % error_count
+        print("Error count : %d" % error_count)
 
     if not valid:
         exit(1)

--- a/tests/test_eadator.py
+++ b/tests/test_eadator.py
@@ -17,16 +17,31 @@ class TestEadator(unittest.TestCase):
                             type=argparse.FileType('r'))
         parser.add_argument('--dtd', default="%s/ents/ead.dtd" % lib_folder, required=False, )
         parser.add_argument('--xsd', default="%s/ents/ead.xsd" % lib_folder, required=False, )
+        parser.add_argument('--count', action='store_true' )
 
         # test valid instances
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'test-dtd-valid.xml')]))
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'test-xsd-valid.xml')]))
-        eadator.validate(os.path.join(cmd_folder,'test-dtd-valid.xml'))
-        eadator.validate(os.path.join(cmd_folder,'test-xsd-valid.xml'))
+
+        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-dtd-valid.xml'))
+        self.assertTrue(valid)
+        self.assertEqual(0,error_count)
+
+        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-xsd-valid.xml'))
+        self.assertTrue(valid)
+        self.assertEqual(0,error_count)
 
         # test invalid instances
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'test-dtd-invalid.xml')]))
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'test-dtd-invalid.xml')]))
+
+        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-dtd-invalid.xml'))
+        self.assertFalse(valid)
+        self.assertEqual(1,error_count)
+
+        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-xsd-invalid.xml'))
+        self.assertFalse(valid)
+        self.assertEqual(1,error_count)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit provides a new, optional, argument to the command line : --count
When enabled, it outputs the total number of errors at the end of the log.

Closes #1