### PR TITLE
1.0.0 a0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ pip install git+git://github.com/eadhost/eadator.git
 
 Requires `libxml2` for `lxml` and validation.  
 
-This utility performs a universial EAD2002 validation.  It exits
-EXIT_SUCCESS (0)  with no output if the file is a valid EAD2002.
+This utility performs a universial EAD validation.  It exits
+EXIT_SUCCESS (0)  with no output if the file is a valid EAD2002 or EAD 3.
 Relevent validation error messages are displaied and the scripts
 exits EXIT_FAILURE (1) if the file is not valid with respect to its
 intended type (XSD or DTD).
@@ -36,7 +36,7 @@ or XSD validation should be used for validation.  There are other minor differen
 in xlink namespaces and in the letter case of xlink attributes.
 
 ```
-usage: eadator [-h] [--dtd DTD] [--xsd XSD] eadfile
+usage: eadator.py [-h] [--dtd DTD] [--xsd XSD] [--rng RNG] [--count] eadfile
 
 EAD validator
 
@@ -45,17 +45,20 @@ positional arguments:
 
 optional arguments:
   -h, --help  show this help message and exit
-  --dtd DTD
-  --xsd XSD
+  --dtd DTD   use alternate EAD2002 DTD
+  --xsd XSD   use alternate EAD2002 XSD
+  --rng RNG   use alternate EAD3 RelaxNG schema
+  --count     report total count of errors
 ```
 
-Comes with default `ead.dtd` and `ead.xsd`, but you can point at
-your own copies on the local filesystem or at URLs on the web.
+Comes with default `ead.dtd`, `ead.xsd`, and `ead3.rng` but you can
+point at your own copies on the local filesystem or at URLs on the
+web.
 
 
 License
 -------
-Copyright © 2014, Regents of the University of California
+Copyright © 2015, Regents of the University of California
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,12 @@ EAD2002 (DTD or XSD) universal validator
 
 travis no longer tests python 2.5, but I think the library might work there.
 
-```
-pip install eadator
-```
-or
-```
-easy_install eadator
-```
+This branch will stay open till EAD 3 is finalized.
 
-or
+see also [pull request #4](https://github.com/eadhost/eadator/pull/4)
+
 ```
-pip install git+git://github.com/eadhost/eadator.git
+pip install https://github.com/eadhost/eadator/tarball/1.0.0-a0
 ```
 
 Requires `libxml2` for `lxml` and validation.  
@@ -36,7 +31,7 @@ or XSD validation should be used for validation.  There are other minor differen
 in xlink namespaces and in the letter case of xlink attributes.
 
 ```
-usage: eadator.py [-h] [--dtd DTD] [--xsd XSD] [--rng RNG] [-v] eadfile
+usage: eadator [-h] [--dtd DTD] [--xsd XSD] [--rng RNG] [-v] eadfile
 
 EAD validator
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ or XSD validation should be used for validation.  There are other minor differen
 in xlink namespaces and in the letter case of xlink attributes.
 
 ```
-usage: eadator.py [-h] [--dtd DTD] [--xsd XSD] [--rng RNG] [--count] eadfile
+usage: eadator.py [-h] [--dtd DTD] [--xsd XSD] [--rng RNG] [-v] eadfile
 
 EAD validator
 
 positional arguments:
-  eadfile     EAD XML file to check
+  eadfile        EAD XML file to check
 
 optional arguments:
-  -h, --help  show this help message and exit
-  --dtd DTD   use alternate EAD2002 DTD
-  --xsd XSD   use alternate EAD2002 XSD
-  --rng RNG   use alternate EAD3 RelaxNG schema
-  --count     report total count of errors
+  -h, --help     show this help message and exit
+  --dtd DTD      use alternate EAD2002 DTD
+  --xsd XSD      use alternate EAD2002 XSD
+  --rng RNG      use alternate EAD3 RelaxNG schema
+  -v, --verbose  report ead type and total count of errors
 ```
 
 Comes with default `ead.dtd`, `ead.xsd`, and `ead3.rng` but you can

--- a/eadator/eadator.py
+++ b/eadator/eadator.py
@@ -38,15 +38,15 @@ def main(argv=None):
         help='use alternate EAD3 RelaxNG schema',
     )
     parser.add_argument(
-        '--count',
+        '-v', '--verbose',
         action='store_true',
-        help='report total count of errors',
+        help='report ead type and total count of errors',
     )
 
     if argv is None:
         argv = parser.parse_args()
 
-    message, valid, error_count = validate(
+    message, valid, error_count, ead_type = validate(
         argv.eadfile[0],
         argv.dtd,
         argv.xsd,
@@ -56,8 +56,8 @@ def main(argv=None):
     if not valid:
         pp(message)
 
-    if argv.count:
-        print("Error count : %d" % error_count)
+    if argv.verbose:
+        print('Type: {1}, Error count: {0}'.format(error_count, ead_type))
 
     if not valid:
         exit(1)
@@ -95,10 +95,13 @@ def validate(eadfile, dtd=None, xsd=None, rng=None):
     # pick the correct validator
     if ead3ns:
         validator = etree.RelaxNG(etree.parse(rng))
+        ead_type = 'EAD3'
     elif ead2002ns:
         validator = etree.XMLSchema(etree.parse(xsd))
+        ead_type = 'EAD2002-XSD'
     else:
         validator = etree.DTD(dtd)
+        ead_type = 'EAD2002-DTD'
 
     valid = validator.validate(eadfile)
 
@@ -109,7 +112,7 @@ def validate(eadfile, dtd=None, xsd=None, rng=None):
         message = validator.error_log
         error_count = len(message)
 
-    return message, valid, error_count
+    return message, valid, error_count, ead_type
 
 
 # main() idiom for importing into REPL for debugging

--- a/eadator/eadator.py
+++ b/eadator/eadator.py
@@ -1,28 +1,57 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """ eadator
-    try DTD and XSD validation for EAD2002, support EAD3 as well later
+    try DTD and XSD validation for EAD2002, RNG for EAD3
 """
-
-import sys, os
 import inspect
-import argparse
-from lxml import etree
+import os
+import sys
 from pprint import pprint as pp
 
+import argparse
+from lxml import etree
+
+
 def main(argv=None):
-    parser = argparse.ArgumentParser( description='EAD validator')
-    parser.add_argument('eadfile', nargs=1, help="EAD XML file to check",
-                        type=argparse.FileType('r'))
-    parser.add_argument('--dtd', required=False, )
-    parser.add_argument('--xsd', required=False, )
-    parser.add_argument('--rng', required=False, )
-    parser.add_argument('--count', action='store_true' )
+    parser = argparse.ArgumentParser(
+        description='EAD validator'
+    )
+    parser.add_argument(
+        'eadfile',
+        nargs=1,
+        help="EAD XML file to check",
+        type=argparse.FileType('r')
+    )
+    parser.add_argument(
+        '--dtd',
+        required=False,
+        help='use alternate EAD2002 DTD',
+    )
+    parser.add_argument(
+        '--xsd',
+        required=False,
+        help='use alternate EAD2002 XSD',
+    )
+    parser.add_argument(
+        '--rng',
+        required=False,
+        help='use alternate EAD3 RelaxNG schema',
+    )
+    parser.add_argument(
+        '--count',
+        action='store_true',
+        help='report total count of errors',
+    )
 
     if argv is None:
         argv = parser.parse_args()
 
-    message, valid, error_count = validate(argv.eadfile[0], argv.dtd, argv.xsd, argv.rng)
+    message, valid, error_count = validate(
+        argv.eadfile[0],
+        argv.dtd,
+        argv.xsd,
+        argv.rng,
+    )
 
     if not valid:
         pp(message)
@@ -32,19 +61,19 @@ def main(argv=None):
 
     if not valid:
         exit(1)
-    
+
+
 def validate(eadfile, dtd=None, xsd=None, rng=None):
     # Info: http://stackoverflow.com/a/6098238/1763984
     # realpath() with make your script run, even if you symlink it :)
-    cmd_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
-
-    eadfile = etree.parse(eadfile)
-
-    ead2002ns = eadfile.xpath("//*[namespace-uri()='urn:isbn:1-931666-22-9']")
-    ead3ns = eadfile.xpath("//*[namespace-uri()='http://ead3.archivists.org/schema/']")
-
-    validator = None
-
+    cmd_folder = os.path.realpath(
+        os.path.abspath(
+            os.path.split(
+                inspect.getfile(inspect.currentframe())
+            )[0]
+        )
+    )
+    # specify alternative schema files
     if not dtd:
         dtd = "%s/ents/ead.dtd" % cmd_folder
     if not xsd:
@@ -52,35 +81,48 @@ def validate(eadfile, dtd=None, xsd=None, rng=None):
     if not rng:
         rng = "%s/ents/ead3.rng" % cmd_folder
 
+    # if it is XML, that's a good start
+    eadfile = etree.parse(eadfile)
+
+    # sniff out any xmlns'es
+    ead2002ns = eadfile.xpath(
+        "//*[namespace-uri()='urn:isbn:1-931666-22-9']"
+    )
+    ead3ns = eadfile.xpath(
+        "//*[namespace-uri()='http://ead3.archivists.org/schema/']"
+    )
+
+    # pick the correct validator
     if ead3ns:
         validator = etree.RelaxNG(etree.parse(rng))
-    elif not ead2002ns:		# looks like DTD style
-        validator = etree.DTD(dtd)
-    else:			# looks like XSD style
+    elif ead2002ns:
         validator = etree.XMLSchema(etree.parse(xsd))
+    else:
+        validator = etree.DTD(dtd)
 
-    message = None
-    error_count = 0
     valid = validator.validate(eadfile)
 
-    if not valid:
+    if valid:
+        message = None
+        error_count = 0
+    else:
         message = validator.error_log
         error_count = len(message)
 
     return message, valid, error_count
-    
 
-# main() idiom for importing into REPL for debugging 
+
+# main() idiom for importing into REPL for debugging
 if __name__ == "__main__":
-
     sys.exit(main())
 
-# Copyright © 2013, Regents of the University of California
+
+# Copyright © 2015, Regents of the University of California
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # - Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the following disclaimer.
 # - Redistributions in binary form must reproduce the above copyright notice,
@@ -89,7 +131,7 @@ if __name__ == "__main__":
 # - Neither the name of the University of California nor the names of its
 #   contributors may be used to endorse or promote products derived from this
 #   software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/eadator/ents/ead3.rng
+++ b/eadator/ents/ead3.rng
@@ -1,0 +1,3308 @@
+<?xml version="1.0" encoding="UTF-8"?><grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes" ns="http://ead3.archivists.org/schema/">
+    <rng:div xmlns:rng="http://relaxng.org/ns/structure/1.0">
+<!--include "ead_revised_defs.rng"-->
+<rng:div datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <!-- ELEMENTS -->
+  <rng:define name="e.ead">
+    <element name="ead">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.relatedencoding"/>
+      </optional>
+      <optional>
+        <ref name="a.base"/>
+      </optional>
+      <ref name="e.control"/>
+      <ref name="e.archdesc"/>
+    </element>
+  </rng:define>
+  <!-- control -->
+  <rng:define name="e.control">
+    <element name="control">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.relatedencoding"/>
+      </optional>
+      <optional>
+        <ref name="a.base"/>
+      </optional>
+      <optional>
+        <attribute name="langencoding">
+          <choice>
+            <value>iso639-1</value>
+            <value>iso639-2b</value>
+            <value>iso639-3</value>
+            <value>otherlangencoding</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="scriptencoding">
+          <choice>
+            <value>iso15924</value>
+            <value>otherscriptencoding</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="dateencoding">
+          <choice>
+            <value>iso8601</value>
+            <value>otherdateencoding</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="countryencoding">
+          <choice>
+            <value>iso3166-1</value>
+            <value>othercountryencoding</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="repositoryencoding">
+          <choice>
+            <value>iso15511</value>
+            <value>otherrepositoryencoding</value>
+          </choice>
+        </attribute>
+      </optional>
+      <element name="recordid">
+        <ref name="am.common"/>
+        <optional>
+          <ref name="a.encodinganalog"/>
+        </optional>
+        <optional>
+          <attribute name="instanceurl">
+            <data type="anyURI"/>
+          </attribute>
+        </optional>
+        <text/>
+      </element>
+      <zeroOrMore>
+        <element name="otherrecordid">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <text/>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="representation">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <ref name="am.simplelink"/>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <text/>
+        </element>
+      </zeroOrMore>
+      <element name="filedesc">
+        <ref name="am.common"/>
+        <optional>
+          <ref name="a.encodinganalog"/>
+        </optional>
+        <element name="titlestmt">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <oneOrMore>
+            <ref name="e.titleproper"/>
+          </oneOrMore>
+          <zeroOrMore>
+            <ref name="e.subtitle"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="e.author"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="e.sponsor"/>
+          </zeroOrMore>
+        </element>
+        <optional>
+          <element name="editionstmt">
+            <ref name="am.common"/>
+            <optional>
+              <ref name="a.encodinganalog"/>
+            </optional>
+            <oneOrMore>
+              <choice>
+                <ref name="e.edition"/>
+                <ref name="e.p"/>
+              </choice>
+            </oneOrMore>
+          </element>
+        </optional>
+        <optional>
+          <element name="publicationstmt">
+            <ref name="am.common"/>
+            <optional>
+              <ref name="a.encodinganalog"/>
+            </optional>
+            <oneOrMore>
+              <choice>
+                <ref name="e.publisher"/>
+                <ref name="e.date"/>
+                <ref name="e.address"/>
+                <ref name="e.num"/>
+                <ref name="e.p"/>
+              </choice>
+            </oneOrMore>
+          </element>
+        </optional>
+        <optional>
+          <element name="seriesstmt">
+            <ref name="am.common"/>
+            <optional>
+              <ref name="a.encodinganalog"/>
+            </optional>
+            <oneOrMore>
+              <choice>
+                <ref name="e.titleproper"/>
+                <ref name="e.num"/>
+                <ref name="e.p"/>
+              </choice>
+            </oneOrMore>
+          </element>
+        </optional>
+        <optional>
+          <element name="notestmt">
+            <ref name="am.common"/>
+            <optional>
+              <ref name="a.encodinganalog"/>
+            </optional>
+            <oneOrMore>
+              <ref name="e.controlnote"/>
+            </oneOrMore>
+          </element>
+        </optional>
+      </element>
+      <element name="maintenancestatus">
+        <ref name="am.common"/>
+        <optional>
+          <ref name="a.encodinganalog"/>
+        </optional>
+        <attribute name="value">
+          <choice>
+            <value>revised</value>
+            <value>deleted</value>
+            <value>new</value>
+            <value>deletedsplit</value>
+            <value>deletedmerged</value>
+            <value>deletedreplaced</value>
+            <value>cancelled</value>
+            <value>derived</value>
+          </choice>
+        </attribute>
+        <text/>
+      </element>
+      <optional>
+        <element name="publicationstatus">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <attribute name="value">
+            <choice>
+              <value>inprocess</value>
+              <value>approved</value>
+              <value>published</value>
+            </choice>
+          </attribute>
+          <text/>
+        </element>
+      </optional>
+      <ref name="e.maintenanceagency"/>
+      <zeroOrMore>
+        <element name="languagedeclaration">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <ref name="e.language"/>
+          <ref name="e.script"/>
+          <optional>
+            <ref name="e.descriptivenote"/>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="conventiondeclaration">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <optional>
+            <ref name="e.abbr"/>
+          </optional>
+          <ref name="e.citation"/>
+          <optional>
+            <ref name="e.descriptivenote"/>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="localtypedeclaration">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <optional>
+            <ref name="e.abbr"/>
+          </optional>
+          <ref name="e.citation"/>
+          <optional>
+            <ref name="e.descriptivenote"/>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="localcontrol">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <optional>
+            <element name="term">
+              <ref name="am.common"/>
+              <optional>
+                <ref name="a.encodinganalog"/>
+              </optional>
+              <optional>
+                <ref name="a.transliteration"/>
+              </optional>
+              <optional>
+                <ref name="a.lastdatetimeverified"/>
+              </optional>
+              <ref name="am.access.no.normal"/>
+              <text/>
+            </element>
+          </optional>
+          <optional>
+            <choice>
+              <ref name="e.datesingle"/>
+              <ref name="e.daterange"/>
+            </choice>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <element name="maintenancehistory">
+        <ref name="am.common"/>
+        <optional>
+          <ref name="a.encodinganalog"/>
+        </optional>
+        <oneOrMore>
+          <element name="maintenanceevent">
+            <ref name="am.common"/>
+            <optional>
+              <ref name="a.encodinganalog"/>
+            </optional>
+            <element name="eventtype">
+              <ref name="am.common"/>
+              <optional>
+                <ref name="a.encodinganalog"/>
+              </optional>
+              <attribute name="value">
+                <choice>
+                  <value>created</value>
+                  <value>revised</value>
+                  <value>deleted</value>
+                  <value>cancelled</value>
+                  <value>derived</value>
+                  <value>updated</value>
+                  <value>unknown</value>
+                </choice>
+              </attribute>
+              <text/>
+            </element>
+            <element name="eventdatetime">
+              <ref name="am.common"/>
+              <optional>
+                <ref name="a.encodinganalog"/>
+              </optional>
+              <optional>
+                <attribute name="standarddatetime">
+                  <choice>
+                    <data type="date">
+                      <param name="maxInclusive">2099-12-31</param>
+                    </data>
+                    <data type="gYear">
+                      <param name="maxInclusive">2099</param>
+                    </data>
+                    <data type="gYearMonth">
+                      <param name="maxInclusive">2099-12</param>
+                    </data>
+                    <data type="dateTime">
+                      <param name="maxInclusive">2099-12-31T23:59:59</param>
+                    </data>
+                  </choice>
+                </attribute>
+              </optional>
+              <text/>
+            </element>
+            <element name="agenttype">
+              <ref name="am.common"/>
+              <optional>
+                <ref name="a.encodinganalog"/>
+              </optional>
+              <attribute name="value">
+                <choice>
+                  <value>human</value>
+                  <value>machine</value>
+                  <value>unknown</value>
+                </choice>
+              </attribute>
+              <text/>
+            </element>
+            <element name="agent">
+              <ref name="am.common"/>
+              <optional>
+                <ref name="a.encodinganalog"/>
+              </optional>
+              <text/>
+            </element>
+            <zeroOrMore>
+              <element name="eventdescription">
+                <ref name="am.common"/>
+                <optional>
+                  <ref name="a.encodinganalog"/>
+                </optional>
+                <optional>
+                  <ref name="a.localtype"/>
+                </optional>
+                <text/>
+              </element>
+            </zeroOrMore>
+          </element>
+        </oneOrMore>
+      </element>
+      <optional>
+        <element name="sources">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <optional>
+            <ref name="a.base"/>
+          </optional>
+          <oneOrMore>
+            <element name="source">
+              <ref name="am.common"/>
+              <optional>
+                <ref name="a.encodinganalog"/>
+              </optional>
+              <optional>
+                <ref name="a.lastdatetimeverified"/>
+              </optional>
+              <ref name="am.simplelink"/>
+              <zeroOrMore>
+                <element name="sourceentry">
+                  <ref name="am.common"/>
+                  <optional>
+                    <ref name="a.encodinganalog"/>
+                  </optional>
+                  <optional>
+                    <ref name="a.transliteration"/>
+                  </optional>
+                  <text/>
+                </element>
+              </zeroOrMore>
+              <optional>
+                <ref name="e.objectxmlwrap"/>
+              </optional>
+              <optional>
+                <ref name="e.descriptivenote"/>
+              </optional>
+            </element>
+          </oneOrMore>
+        </element>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.titleproper">
+    <element name="titleproper">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.render"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.subtitle">
+    <element name="subtitle">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.author">
+    <element name="author">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.sponsor">
+    <element name="sponsor">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.edition">
+    <element name="edition">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.publisher">
+    <element name="publisher">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.controlnote">
+    <element name="controlnote">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <oneOrMore>
+        <ref name="m.blocks"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.maintenanceagency">
+    <element name="maintenanceagency">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="am.countrycode"/>
+      <optional>
+        <element name="agencycode">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <text/>
+        </element>
+      </optional>
+      <zeroOrMore>
+        <element name="otheragencycode">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <text/>
+        </element>
+      </zeroOrMore>
+      <oneOrMore>
+        <element name="agencyname">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <text/>
+        </element>
+      </oneOrMore>
+      <optional>
+        <ref name="e.descriptivenote"/>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.citation">
+    <element name="citation">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="am.simplelink"/>
+      <optional>
+        <ref name="a.lastdatetimeverified"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <!-- ARCHDESC -->
+  <rng:define name="e.archdesc">
+    <element name="archdesc">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.relatedencoding"/>
+      </optional>
+      <ref name="am.desc.base"/>
+      <ref name="a.level"/>
+      <optional>
+        <ref name="a.base"/>
+      </optional>
+      <ref name="e.did"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="m.desc.base"/>
+          <ref name="e.dsc"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <!-- did -->
+  <rng:define name="e.did">
+    <element name="did">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <ref name="m.did"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.abstract">
+    <element name="abstract">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic.plus.access"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.container">
+    <element name="container">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.parent"/>
+      </optional>
+      <optional>
+        <attribute name="containerid">
+          <data type="NMTOKEN"/>
+        </attribute>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.dao">
+    <element name="dao">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <ref name="am.simplelink"/>
+      <optional>
+        <ref name="a.identifier"/>
+      </optional>
+      <optional>
+        <ref name="a.link.xpointer"/>
+      </optional>
+      <optional>
+        <ref name="a.entityref"/>
+      </optional>
+      <attribute name="daotype">
+        <choice>
+          <value>borndigital</value>
+          <value>derived</value>
+          <value>unknown</value>
+          <value>otherdaotype</value>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="otherdaotype"/>
+      </optional>
+      <optional>
+        <ref name="a.coverage"/>
+      </optional>
+      <optional>
+        <ref name="e.descriptivenote"/>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.daoset">
+    <element name="daoset">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.coverage"/>
+      </optional>
+      <optional>
+        <ref name="a.base"/>
+      </optional>
+      <ref name="e.dao"/>
+      <oneOrMore>
+        <ref name="e.dao"/>
+      </oneOrMore>
+      <optional>
+        <ref name="e.descriptivenote"/>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.didnote">
+    <element name="didnote">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.langmaterial">
+    <element name="langmaterial">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="e.language"/>
+          <ref name="e.languageset"/>
+        </choice>
+      </oneOrMore>
+      <optional>
+        <ref name="e.descriptivenote"/>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.materialspec">
+    <element name="materialspec">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.physdescset">
+    <element name="physdescset">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <attribute name="parallel">
+          <ref name="av.boolean"/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="a.coverage"/>
+      </optional>
+      <ref name="e.physdescstructured"/>
+      <oneOrMore>
+        <ref name="e.physdescstructured"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.physdesc">
+    <element name="physdesc">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.physloc">
+    <element name="physloc">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.parent"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.origination">
+    <element name="origination">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="e.corpname"/>
+          <ref name="e.famname"/>
+          <ref name="e.name"/>
+          <ref name="e.persname"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.physdescstructured">
+    <element name="physdescstructured">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <attribute name="physdescstructuredtype">
+        <choice>
+          <value>carrier</value>
+          <value>materialtype</value>
+          <value>spaceoccupied</value>
+          <value>otherphysdescstructuredtype</value>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="otherphysdescstructuredtype"/>
+      </optional>
+      <ref name="a.coverage"/>
+      <element name="quantity">
+        <ref name="am.common"/>
+        <optional>
+          <ref name="a.encodinganalog"/>
+        </optional>
+        <optional>
+          <attribute name="approximate">
+            <ref name="av.boolean"/>
+          </attribute>
+        </optional>
+        <text/>
+      </element>
+      <element name="unittype">
+        <ref name="am.common"/>
+        <optional>
+          <ref name="a.encodinganalog"/>
+        </optional>
+        <ref name="am.access.no.normal"/>
+        <text/>
+      </element>
+      <zeroOrMore>
+        <choice>
+          <ref name="e.physfacet"/>
+          <ref name="e.dimensions"/>
+        </choice>
+      </zeroOrMore>
+      <optional>
+        <ref name="e.descriptivenote"/>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.repository">
+    <element name="repository">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="e.corpname"/>
+          <ref name="e.famname"/>
+          <ref name="e.name"/>
+          <ref name="e.persname"/>
+        </choice>
+      </oneOrMore>
+      <optional>
+        <ref name="e.address"/>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.unitdate">
+    <element name="unitdate">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <ref name="a.unitdatetype"/>
+      <optional>
+        <ref name="a.datechar"/>
+      </optional>
+      <optional>
+        <ref name="a.certainty"/>
+      </optional>
+      <ref name="am.dates.era"/>
+      <ref name="am.dates.calendar"/>
+      <ref name="am.date.normal"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.unitdatestructured">
+    <element name="unitdatestructured">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <ref name="a.unitdatetype"/>
+      <optional>
+        <ref name="a.datechar"/>
+      </optional>
+      <optional>
+        <ref name="a.certainty"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="am.dates.era"/>
+      <ref name="am.dates.calendar"/>
+      <choice>
+        <ref name="e.datesingle"/>
+        <ref name="e.daterange"/>
+        <ref name="e.dateset"/>
+      </choice>
+    </element>
+  </rng:define>
+  <rng:define name="e.unittitle">
+    <element name="unittitle">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <attribute name="normal">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <ref name="m.mixed.basic.plus.access"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.unitid">
+    <element name="unitid">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <ref name="am.countrycode"/>
+      <optional>
+        <attribute name="repositorycode">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="identifier"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <!-- archdesc notes -->
+  <rng:define name="e.accessrestrict">
+    <element name="accessrestrict">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.accessrestrict"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.accruals">
+    <element name="accruals">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.accruals"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.acqinfo">
+    <element name="acqinfo">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.acqinfo"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.altformavail">
+    <element name="altformavail">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.altformavail"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.appraisal">
+    <element name="appraisal">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.appraisal"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.arrangement">
+    <element name="arrangement">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.arrangement"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.bibliography">
+    <element name="bibliography">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.bibliography"/>
+          <ref name="e.archref"/>
+          <ref name="e.bibref"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.bioghist">
+    <element name="bioghist">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.bioghist"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.controlaccess">
+    <element name="controlaccess">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="m.access"/>
+          <ref name="e.controlaccess"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.custodhist">
+    <element name="custodhist">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.custodhist"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.fileplan">
+    <element name="fileplan">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.fileplan"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.index">
+    <element name="index">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="m.blocks"/>
+      </zeroOrMore>
+      <choice>
+        <group>
+          <optional>
+            <ref name="e.listhead"/>
+          </optional>
+          <oneOrMore>
+            <ref name="e.indexentry"/>
+          </oneOrMore>
+        </group>
+        <oneOrMore>
+          <ref name="e.index"/>
+        </oneOrMore>
+      </choice>
+    </element>
+  </rng:define>
+  <rng:define name="e.indexentry">
+    <element name="indexentry">
+      <ref name="am.common"/>
+      <choice>
+        <element name="namegrp">
+          <ref name="am.common"/>
+          <oneOrMore>
+            <ref name="m.access"/>
+          </oneOrMore>
+        </element>
+        <ref name="m.access"/>
+      </choice>
+      <optional>
+        <choice>
+          <element name="ptrgrp">
+            <ref name="am.common"/>
+            <oneOrMore>
+              <ref name="m.refs"/>
+            </oneOrMore>
+          </element>
+          <ref name="m.refs"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="e.indexentry"/>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.legalstatus">
+    <element name="legalstatus">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.legalstatus"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.odd">
+    <element name="odd">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.odd"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.originalsloc">
+    <element name="originalsloc">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.originalsloc"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.otherfindaid">
+    <element name="otherfindaid">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.otherfindaid"/>
+          <ref name="e.archref"/>
+          <ref name="e.bibref"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.phystech">
+    <element name="phystech">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.phystech"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.prefercite">
+    <element name="prefercite">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.prefercite"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.processinfo">
+    <element name="processinfo">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.processinfo"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.relatedmaterial">
+    <element name="relatedmaterial">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.relatedmaterial"/>
+          <ref name="e.archref"/>
+          <ref name="e.bibref"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.scopecontent">
+    <element name="scopecontent">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.scopecontent"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.separatedmaterial">
+    <element name="separatedmaterial">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.separatedmaterial"/>
+          <ref name="e.archref"/>
+          <ref name="e.bibref"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.userestrict">
+    <element name="userestrict">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="m.blocks"/>
+          <ref name="e.userestrict"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <!-- controlaccess elements -->
+  <rng:define name="e.corpname">
+    <element name="corpname">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.famname">
+    <element name="famname">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.function">
+    <element name="function">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.genreform">
+    <element name="genreform">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.geogname">
+    <element name="geogname">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+      <zeroOrMore>
+        <element name="geographiccoordinates">
+          <ref name="am.common"/>
+          <attribute name="coordinatesystem">
+            <data type="token"/>
+          </attribute>
+          <text/>
+        </element>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.name">
+    <element name="name">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.occupation">
+    <element name="occupation">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.persname">
+    <element name="persname">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.subject">
+    <element name="subject">
+      <ref name="am.common"/>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.title">
+    <element name="title">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <ref name="am.access"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.relator"/>
+      </optional>
+      <optional>
+        <ref name="a.render"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.part"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.part">
+    <element name="part">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <ref name="am.access.no.normal"/>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <!-- BLOCKS -->
+  <!-- p -->
+  <rng:define name="e.p">
+    <element name="p">
+      <ref name="am.common"/>
+      <ref name="m.para.content"/>
+    </element>
+  </rng:define>
+  <!-- blockquote -->
+  <rng:define name="e.blockquote">
+    <element name="blockquote">
+      <ref name="am.common"/>
+      <oneOrMore>
+        <choice>
+          <ref name="m.inter.noquote"/>
+          <ref name="e.p"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <!-- chronlist -->
+  <rng:define name="e.chronlist">
+    <element name="chronlist">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <optional>
+        <ref name="e.listhead"/>
+      </optional>
+      <oneOrMore>
+        <element name="chronitem">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <choice>
+            <ref name="e.datesingle"/>
+            <ref name="e.daterange"/>
+            <ref name="e.dateset"/>
+          </choice>
+          <choice>
+            <group>
+              <optional>
+                <ref name="e.geogname"/>
+              </optional>
+              <ref name="e.event"/>
+            </group>
+            <oneOrMore>
+              <element name="chronitemset">
+                <ref name="am.common"/>
+                <zeroOrMore>
+                  <ref name="e.geogname"/>
+                </zeroOrMore>
+                <oneOrMore>
+                  <ref name="e.event"/>
+                </oneOrMore>
+              </element>
+            </oneOrMore>
+          </choice>
+        </element>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.event">
+    <element name="event">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <ref name="m.para.content"/>
+    </element>
+  </rng:define>
+  <!-- list -->
+  <rng:define name="e.list">
+    <element name="list">
+      <ref name="am.common"/>
+      <optional>
+        <attribute name="listtype">
+          <choice>
+            <value>deflist</value>
+            <value>unordered</value>
+            <value>ordered</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mark">
+          <choice>
+            <value>disc</value>
+            <value>circle</value>
+            <value>square</value>
+            <value>decimal</value>
+            <value>decimal-leading-zero</value>
+            <value>lower-roman</value>
+            <value>upper-roman</value>
+            <value>lower-greek</value>
+            <value>lower-latin</value>
+            <value>upper-latin</value>
+            <value>armenian</value>
+            <value>georgian</value>
+            <value>lower-alpha</value>
+            <value>upper-alpha</value>
+            <value>none</value>
+            <value>inherit</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="numeration">
+          <choice>
+            <value>arabic</value>
+            <value>upperalpha</value>
+            <value>loweralpha</value>
+            <value>upperroman</value>
+            <value>lowerroman</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <choice>
+        <oneOrMore>
+          <ref name="e.item"/>
+        </oneOrMore>
+        <group>
+          <optional>
+            <ref name="e.listhead"/>
+          </optional>
+          <oneOrMore>
+            <element name="defitem">
+              <ref name="am.common"/>
+              <element name="label">
+                <ref name="am.common"/>
+                <ref name="m.mixed.basic"/>
+              </element>
+              <ref name="e.item"/>
+            </element>
+          </oneOrMore>
+        </group>
+      </choice>
+    </element>
+  </rng:define>
+  <rng:define name="e.item">
+    <element name="item">
+      <ref name="am.common"/>
+      <ref name="m.para.content"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.listhead">
+    <element name="listhead">
+      <ref name="am.common"/>
+      <optional>
+        <element name="head01">
+          <ref name="am.common"/>
+          <ref name="m.mixed.basic"/>
+        </element>
+      </optional>
+      <optional>
+        <element name="head02">
+          <ref name="am.common"/>
+          <ref name="m.mixed.basic"/>
+        </element>
+      </optional>
+      <optional>
+        <element name="head03">
+          <ref name="am.common"/>
+          <ref name="m.mixed.basic"/>
+        </element>
+      </optional>
+    </element>
+  </rng:define>
+  <!-- table -->
+  <rng:define name="e.table">
+    <element name="table">
+      <ref name="am.common"/>
+      <optional>
+        <attribute name="frame">
+          <choice>
+            <value>top</value>
+            <value>bottom</value>
+            <value>topbot</value>
+            <value>all</value>
+            <value>sides</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="a.colsep"/>
+      </optional>
+      <optional>
+        <ref name="a.rowsep"/>
+      </optional>
+      <optional>
+        <attribute name="pgwide">
+          <ref name="av.boolean"/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="e.head"/>
+      </optional>
+      <oneOrMore>
+        <element name="tgroup">
+          <ref name="am.common"/>
+          <attribute name="cols">
+            <data type="NMTOKEN"/>
+          </attribute>
+          <optional>
+            <ref name="a.colsep"/>
+          </optional>
+          <optional>
+            <ref name="a.rowsep"/>
+          </optional>
+          <optional>
+            <ref name="a.align"/>
+          </optional>
+          <zeroOrMore>
+            <element name="colspec">
+              <optional>
+                <attribute name="colnum">
+                  <data type="NMTOKEN"/>
+                </attribute>
+              </optional>
+              <optional>
+                <ref name="a.colname"/>
+              </optional>
+              <optional>
+                <attribute name="colwidth">
+                  <data type="token"/>
+                </attribute>
+              </optional>
+              <optional>
+                <ref name="a.colsep"/>
+              </optional>
+              <optional>
+                <ref name="a.rowsep"/>
+              </optional>
+              <optional>
+                <ref name="a.align"/>
+              </optional>
+              <optional>
+                <ref name="a.char"/>
+              </optional>
+              <optional>
+                <ref name="a.charoff"/>
+              </optional>
+              <empty/>
+            </element>
+          </zeroOrMore>
+          <optional>
+            <ref name="e.thead"/>
+          </optional>
+          <element name="tbody">
+            <ref name="am.common"/>
+            <optional>
+              <ref name="a.valign"/>
+            </optional>
+            <oneOrMore>
+              <ref name="e.row"/>
+            </oneOrMore>
+          </element>
+        </element>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.row">
+    <element name="row">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.rowsep"/>
+      </optional>
+      <optional>
+        <ref name="a.valign"/>
+      </optional>
+      <oneOrMore>
+        <element name="entry">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.colname"/>
+          </optional>
+          <optional>
+            <attribute name="namest">
+              <data type="NMTOKEN"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="nameend">
+              <data type="NMTOKEN"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="morerows">
+              <data type="NMTOKEN"/>
+            </attribute>
+          </optional>
+          <optional>
+            <ref name="a.colsep"/>
+          </optional>
+          <optional>
+            <ref name="a.rowsep"/>
+          </optional>
+          <optional>
+            <ref name="a.align"/>
+          </optional>
+          <optional>
+            <ref name="a.char"/>
+          </optional>
+          <optional>
+            <ref name="a.charoff"/>
+          </optional>
+          <optional>
+            <ref name="a.valign"/>
+          </optional>
+          <ref name="m.para.content"/>
+        </element>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.thead">
+    <element name="thead">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.valign"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.row"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <!-- language blocks -->
+  <rng:define name="e.language">
+    <element name="language">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+      <optional>
+        <attribute name="langcode">
+          <data type="NMTOKEN"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </rng:define>
+  <rng:define name="e.languageset">
+    <element name="languageset">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.language"/>
+      </oneOrMore>
+      <oneOrMore>
+        <ref name="e.script"/>
+      </oneOrMore>
+      <optional>
+        <ref name="e.descriptivenote"/>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.script">
+    <element name="script">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.label"/>
+      </optional>
+
+      <optional>
+        <attribute name="scriptcode">
+          <data type="NMTOKEN"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </rng:define>
+  <!-- physdescstructured blocks -->
+  <rng:define name="e.dimensions">
+    <element name="dimensions">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <attribute name="unit">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="m.mixed.basic.elements"/>
+          <ref name="e.dimensions"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.physfacet">
+    <element name="physfacet">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="am.access.no.normal"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <ref name="m.mixed.basic.plus.access"/>
+    </element>
+  </rng:define>
+  <!-- other blocks -->
+  <rng:define name="e.address">
+    <element name="address">
+      <ref name="am.common"/>
+      <oneOrMore>
+        <element name="addressline">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <ref name="m.mixed.basic"/>
+        </element>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.archref">
+    <element name="archref">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic.plus.access"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.bibref">
+    <element name="bibref">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic.plus.access"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.descriptivenote">
+    <element name="descriptivenote">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <oneOrMore>
+        <ref name="e.p"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.footnote">
+    <element name="footnote">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.link.show"/>
+      </optional>
+      <optional>
+        <ref name="a.link.actuate"/>
+      </optional>
+      <oneOrMore>
+        <ref name="m.blocks"/>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.head">
+    <element name="head">
+      <ref name="am.common"/>
+      <optional>
+        <attribute name="althead">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <!-- DATES -->
+  <rng:define name="e.datesingle">
+    <element name="datesingle">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <ref name="m.datesingle"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.daterange">
+    <element name="daterange">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <element name="fromdate">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <ref name="m.datesingle"/>
+        </element>
+      </optional>
+      <optional>
+        <element name="todate">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.localtype"/>
+          </optional>
+          <ref name="m.datesingle"/>
+        </element>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.dateset">
+    <element name="dateset">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <choice>
+        <ref name="e.datesingle"/>
+        <ref name="e.daterange"/>
+      </choice>
+      <oneOrMore>
+        <choice>
+          <ref name="e.datesingle"/>
+          <ref name="e.daterange"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <!-- MIXED CONTENT -->
+  <rng:define name="e.abbr">
+    <element name="abbr">
+      <ref name="am.common"/>
+      <optional>
+        <attribute name="expan">
+          <data type="string"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </rng:define>
+  <rng:define name="e.date">
+    <element name="date">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <ref name="am.dates.era"/>
+      <ref name="am.dates.calendar"/>
+      <ref name="am.date.normal"/>
+      <optional>
+        <ref name="a.certainty"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.emph">
+    <element name="emph">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.render"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.expan">
+    <element name="expan">
+      <ref name="am.common"/>
+      <optional>
+        <attribute name="abbr">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </rng:define>
+  <rng:define name="e.foreign">
+    <element name="foreign">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.render"/>
+      </optional>
+      <text/>
+    </element>
+  </rng:define>
+  <rng:define name="e.lb">
+    <element name="lb">
+      <empty/>
+    </element>
+  </rng:define>
+  <rng:define name="e.num">
+    <element name="num">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.quote">
+    <element name="quote">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <ref name="m.mixed.basic"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.ptr">
+    <element name="ptr">
+      <ref name="am.common.empty"/>
+      <ref name="am.internal.ptr"/>
+      <optional>
+        <ref name="a.entityref"/>
+      </optional>
+      <empty/>
+    </element>
+  </rng:define>
+  <rng:define name="e.ref">
+    <element name="ref">
+      <ref name="am.common"/>
+      <ref name="am.internal.ptr"/>
+      <optional>
+        <ref name="a.entityref"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="e.abbr"/>
+          <ref name="e.expan"/>
+          <ref name="e.emph"/>
+          <ref name="e.lb"/>
+          <ref name="e.ptr"/>
+          <ref name="e.quote"/>
+          <ref name="e.num"/>
+          <ref name="e.footnote"/>
+          <ref name="e.date"/>
+          <ref name="m.access"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <!-- DSC -->
+  <rng:define name="e.dsc">
+    <element name="dsc">
+      <ref name="am.common"/>
+      <optional>
+        <attribute name="dsctype">
+          <choice>
+            <value>analyticover</value>
+            <value>combined</value>
+            <value>in-depth</value>
+            <value>otherdsctype</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="otherdsctype">
+          <data type="NMTOKEN"/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <group>
+        <optional>
+          <ref name="e.head"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="m.blocks"/>
+        </zeroOrMore>
+      </group>
+      <optional>
+        <ref name="e.thead"/>
+      </optional>
+      <optional>
+        <ref name="m.cOrC01"/>
+      </optional>
+    </element>
+  </rng:define>
+  <rng:define name="e.c">
+    <element name="c">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c01">
+    <element name="c01">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c02"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c02">
+    <element name="c02">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c03"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c03">
+    <element name="c03">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c04"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c04">
+    <element name="c04">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c05"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c05">
+    <element name="c05">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c06"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c06">
+    <element name="c06">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c07"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c07">
+    <element name="c07">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c08"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c08">
+    <element name="c08">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="e.c09"/>
+        </zeroOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c09">
+    <element name="c09">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c10"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c10">
+    <element name="c10">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c11"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c11">
+    <element name="c11">
+      <ref name="m.c.base"/>
+      <zeroOrMore>
+        <optional>
+          <ref name="e.thead"/>
+        </optional>
+        <oneOrMore>
+          <ref name="e.c12"/>
+        </oneOrMore>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.c12">
+    <element name="c12">
+      <ref name="m.c.base"/>
+    </element>
+  </rng:define>
+  <!-- RELATIONS -->
+  <rng:define name="e.relations">
+    <element name="relations">
+      <ref name="am.common"/>
+      <optional>
+        <ref name="a.encodinganalog"/>
+      </optional>
+      <optional>
+        <ref name="a.localtype"/>
+      </optional>
+      <optional>
+        <ref name="a.base"/>
+      </optional>
+      <oneOrMore>
+        <element name="relation">
+          <ref name="am.common"/>
+          <optional>
+            <ref name="a.encodinganalog"/>
+          </optional>
+          <attribute name="relationtype">
+            <choice>
+              <value>cpfrelation</value>
+              <value>resourcerelation</value>
+              <value>functionrelation</value>
+              <value>otherrelationtype</value>
+            </choice>
+          </attribute>
+          <optional>
+            <attribute name="otherrelationtype">
+              <data type="string"/>
+            </attribute>
+          </optional>
+          <optional>
+            <ref name="a.lastdatetimeverified"/>
+          </optional>
+          <ref name="am.simplelink"/>
+          <zeroOrMore>
+            <element name="relationentry">
+              <ref name="am.common"/>
+              <optional>
+                <ref name="a.encodinganalog"/>
+              </optional>
+              <optional>
+                <ref name="a.localtype"/>
+              </optional>
+              <optional>
+                <ref name="a.transliteration"/>
+              </optional>
+              <text/>
+            </element>
+          </zeroOrMore>
+          <optional>
+            <ref name="e.objectxmlwrap"/>
+          </optional>
+          <optional>
+            <choice>
+              <ref name="e.datesingle"/>
+              <ref name="e.daterange"/>
+              <ref name="e.dateset"/>
+            </choice>
+          </optional>
+          <optional>
+            <ref name="e.geogname"/>
+          </optional>
+          <optional>
+            <ref name="e.descriptivenote"/>
+          </optional>
+        </element>
+      </oneOrMore>
+    </element>
+  </rng:define>
+  <rng:define name="e.objectxmlwrap">
+    <element name="objectxmlwrap">
+      <ref name="am.common"/>
+      <ref name="e.anyname"/>
+    </element>
+  </rng:define>
+  <rng:define name="e.anyname">
+    <element>
+      <anyName>
+        <except>
+          <nsName ns="http://ead3.archivists.org/schema/"/>
+        </except>
+      </anyName>
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="e.anyname"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </rng:define>
+  <!-- ELEMENT MODELS -->
+  <rng:define name="m.blocks">
+    <choice>
+      <ref name="m.inter"/>
+      <ref name="e.p"/>
+    </choice>
+  </rng:define>
+  <rng:define name="m.inter">
+    <choice>
+      <ref name="m.inter.noquote"/>
+      <ref name="e.blockquote"/>
+    </choice>
+  </rng:define>
+  <rng:define name="m.inter.noquote">
+    <choice>
+      <ref name="e.chronlist"/>
+      <ref name="e.list"/>
+      <ref name="e.table"/>
+    </choice>
+  </rng:define>
+  <rng:define name="m.cOrC01">
+    <choice>
+      <oneOrMore>
+        <ref name="e.c"/>
+      </oneOrMore>
+      <oneOrMore>
+        <ref name="e.c01"/>
+      </oneOrMore>
+    </choice>
+  </rng:define>
+  <rng:define name="m.c.base">
+    <ref name="am.desc.c"/>
+    <optional>
+      <ref name="e.head"/>
+    </optional>
+    <ref name="e.did"/>
+    <zeroOrMore>
+      <ref name="m.desc.base"/>
+    </zeroOrMore>
+  </rng:define>
+  <rng:define name="m.access">
+    <choice>
+      <ref name="e.persname"/>
+      <ref name="e.corpname"/>
+      <ref name="e.famname"/>
+      <ref name="e.geogname"/>
+      <ref name="e.name"/>
+      <ref name="e.occupation"/>
+      <ref name="e.subject"/>
+      <ref name="e.genreform"/>
+      <ref name="e.function"/>
+      <ref name="e.title"/>
+    </choice>
+  </rng:define>
+  <rng:define name="m.datesingle">
+    <optional>
+      <attribute name="standarddate">
+        <choice>
+          <data type="date">
+            <param name="maxInclusive">2099-12-31</param>
+          </data>
+          <data type="gYear">
+            <param name="maxInclusive">2099</param>
+          </data>
+          <data type="gYearMonth">
+            <param name="maxInclusive">2099-12</param>
+          </data>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="notbefore">
+        <choice>
+          <data type="date">
+            <param name="maxInclusive">2099-12-31</param>
+          </data>
+          <data type="gYear">
+            <param name="maxInclusive">2099</param>
+          </data>
+          <data type="gYearMonth">
+            <param name="maxInclusive">2099-12</param>
+          </data>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="notafter">
+        <choice>
+          <data type="date">
+            <param name="maxInclusive">2099-12-31</param>
+          </data>
+          <data type="gYear">
+            <param name="maxInclusive">2099</param>
+          </data>
+          <data type="gYearMonth">
+            <param name="maxInclusive">2099-12</param>
+          </data>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="m.mixed.basic"/>
+  </rng:define>
+  <rng:define name="m.desc.base">
+    <choice>
+      <ref name="e.accessrestrict"/>
+      <ref name="e.accruals"/>
+      <ref name="e.acqinfo"/>
+      <ref name="e.altformavail"/>
+      <ref name="e.appraisal"/>
+      <ref name="e.arrangement"/>
+      <ref name="e.bibliography"/>
+      <ref name="e.bioghist"/>
+      <ref name="e.controlaccess"/>
+      <ref name="e.custodhist"/>
+      <ref name="e.fileplan"/>
+      <ref name="e.index"/>
+      <ref name="e.legalstatus"/>
+      <ref name="e.odd"/>
+      <ref name="e.originalsloc"/>
+      <ref name="e.otherfindaid"/>
+      <ref name="e.phystech"/>
+      <ref name="e.prefercite"/>
+      <ref name="e.processinfo"/>
+      <ref name="e.relatedmaterial"/>
+      <ref name="e.relations"/>
+      <ref name="e.scopecontent"/>
+      <ref name="e.separatedmaterial"/>
+      <ref name="e.userestrict"/>
+    </choice>
+  </rng:define>
+  <rng:define name="m.did">
+    <choice>
+      <ref name="e.abstract"/>
+      <ref name="e.container"/>
+      <ref name="e.dao"/>
+      <ref name="e.daoset"/>
+      <ref name="e.didnote"/>
+      <ref name="e.langmaterial"/>
+      <ref name="e.materialspec"/>
+      <ref name="e.origination"/>
+      <ref name="e.physdescset"/>
+      <ref name="e.physdesc"/>
+      <ref name="e.physdescstructured"/>
+      <ref name="e.physloc"/>
+      <ref name="e.repository"/>
+      <ref name="e.unitdate"/>
+      <ref name="e.unitdatestructured"/>
+      <ref name="e.unitid"/>
+      <ref name="e.unittitle"/>
+    </choice>
+  </rng:define>
+  <rng:define name="m.refs">
+    <choice>
+      <ref name="e.ptr"/>
+      <ref name="e.ref"/>
+    </choice>
+  </rng:define>
+  <!-- MIXED CONTENT MODELS -->
+  <rng:define name="m.mixed.basic.elements">
+    <choice>
+      <ref name="e.abbr"/>
+      <ref name="e.emph"/>
+      <ref name="e.expan"/>
+      <ref name="e.foreign"/>
+      <ref name="e.lb"/>
+      <ref name="e.ptr"/>
+      <ref name="e.ref"/>
+    </choice>
+  </rng:define>
+  <rng:define name="m.mixed.basic">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="m.mixed.basic.elements"/>
+      </choice>
+    </zeroOrMore>
+  </rng:define>
+  <rng:define name="m.mixed.basic.plus.elements">
+    <choice>
+      <ref name="m.mixed.basic.elements"/>
+      <ref name="e.date"/>
+      <ref name="e.footnote"/>
+      <ref name="e.num"/>
+      <ref name="e.quote"/>
+    </choice>
+  </rng:define>
+  <rng:define name="m.mixed.basic.plus.access">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="m.mixed.basic.elements"/>
+        <ref name="m.access"/>
+        <ref name="e.date"/>
+        <ref name="e.footnote"/>
+        <ref name="e.num"/>
+        <ref name="e.quote"/>
+      </choice>
+    </zeroOrMore>
+  </rng:define>
+  <rng:define name="m.para.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="m.mixed.basic.plus.elements"/>
+        <ref name="m.access"/>
+        <ref name="e.list"/>
+      </choice>
+    </zeroOrMore>
+  </rng:define>
+  <!-- ATTRIBUTE MODELS -->
+  <rng:define name="am.internal.ptr">
+    <optional>
+      <attribute name="target">
+        <data type="IDREF"/>
+      </attribute>
+    </optional>
+    <optional>
+      <ref name="a.link.xpointer"/>
+    </optional>
+    <ref name="am.simplelink"/>
+  </rng:define>
+  <rng:define name="am.simplelink">
+    <optional>
+      <ref name="a.link.href"/>
+    </optional>
+    <optional>
+      <ref name="a.link.role"/>
+    </optional>
+    <optional>
+      <ref name="a.link.arcrole"/>
+    </optional>
+    <optional>
+      <ref name="a.link.title"/>
+    </optional>
+    <optional>
+      <ref name="a.link.show"/>
+    </optional>
+    <optional>
+      <ref name="a.link.actuate"/>
+    </optional>
+  </rng:define>
+  <rng:define name="am.common.empty">
+    <optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altrender">
+        <data type="token"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="audience">
+        <choice>
+          <value>external</value>
+          <value>internal</value>
+        </choice>
+      </attribute>
+    </optional>
+  </rng:define>
+  <rng:define name="am.common">
+    <ref name="am.common.empty"/>
+    <optional>
+      <attribute name="lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="script">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </rng:define>
+  <rng:define name="am.desc.base">
+    <optional>
+      <attribute name="otherlevel">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <optional>
+      <ref name="a.encodinganalog"/>
+    </optional>
+  </rng:define>
+  <rng:define name="am.desc.c">
+    <ref name="am.common"/>
+    <optional>
+      <ref name="a.base"/>
+    </optional>
+    <optional>
+      <ref name="a.level"/>
+    </optional>
+    <ref name="am.desc.base"/>
+  </rng:define>
+  <rng:define name="am.access">
+    <ref name="am.access.no.normal"/>
+    <optional>
+      <ref name="a.normal"/>
+    </optional>
+  </rng:define>
+  <rng:define name="am.access.no.normal">
+    <optional>
+      <attribute name="source">
+        <data type="token"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rules">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <optional>
+      <ref name="a.identifier"/>
+    </optional>
+  </rng:define>
+  <!-- ATTRIBUTE DEFINITIONS -->
+  <!-- xlink-modelled attributes -->
+  <rng:define name="a.link.actuate">
+    <attribute name="actuate">
+      <choice>
+        <value>onload</value>
+        <value>onrequest</value>
+        <value>other</value>
+        <value>none</value>
+      </choice>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.link.arcrole">
+    <attribute name="arcrole">
+      <data type="anyURI"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.link.href">
+    <attribute name="href">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.link.role">
+    <attribute name="linkrole">
+      <data type="anyURI"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.link.show">
+    <attribute name="show">
+      <choice>
+        <value>new</value>
+        <value>replace</value>
+        <value>embed</value>
+        <value>other</value>
+        <value>none</value>
+      </choice>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.link.title">
+    <attribute name="linktitle">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <!--  other linking-related attributes -->
+  <rng:define name="a.base">
+    <attribute name="base">
+      <data type="anyURI"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.identifier">
+    <attribute name="identifier">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.parent">
+    <attribute name="parent">
+      <data type="IDREFS"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.relator">
+    <attribute name="relator">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.link.xpointer">
+    <attribute name="xpointer">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.entityref">
+    <attribute name="entityref">
+      <data type="ENTITY"/>
+    </attribute>
+  </rng:define>
+  <!-- display attributes -->
+  <rng:define name="a.align">
+    <attribute name="align">
+      <choice>
+        <value>left</value>
+        <value>right</value>
+        <value>center</value>
+        <value>justify</value>
+        <value>char</value>
+      </choice>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.valign">
+    <attribute name="valign">
+      <choice>
+        <value>top</value>
+        <value>middle</value>
+        <value>bottom</value>
+      </choice>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.render">
+    <attribute name="render">
+      <choice>
+        <value>altrender</value>
+        <value>bold</value>
+        <value>bolddoublequote</value>
+        <value>bolditalic</value>
+        <value>boldsinglequote</value>
+        <value>boldsmcaps</value>
+        <value>boldunderline</value>
+        <value>doublequote</value>
+        <value>italic</value>
+        <value>nonproport</value>
+        <value>singlequote</value>
+        <value>smcaps</value>
+        <value>sub</value>
+        <value>super</value>
+        <value>underline</value>
+      </choice>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.label">
+
+    <attribute name="label">
+      <data type="string"/>
+    </attribute>
+
+  </rng:define>
+  <!-- date attributes -->
+  <rng:define name="am.dates.calendar">
+    <optional>
+      <attribute name="calendar">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </rng:define>
+  <rng:define name="am.dates.era">
+    <optional>
+      <attribute name="era">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </rng:define>
+  <rng:define name="am.date.normal">
+    <optional>
+      <ref name="a.normal"/>
+    </optional>
+  </rng:define>
+  <rng:define name="a.lastdatetimeverified">
+    <attribute name="lastdatetimeverified">
+      <choice>
+        <data type="date">
+          <param name="maxInclusive">2099-12-31</param>
+        </data>
+        <data type="gYear">
+          <param name="maxInclusive">2099</param>
+        </data>
+        <data type="gYearMonth">
+          <param name="maxInclusive">2099-12</param>
+        </data>
+        <data type="dateTime">
+          <param name="maxInclusive">2099-12-31T23:59:59</param>
+        </data>
+      </choice>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.datechar">
+    <attribute name="datechar">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.certainty">
+    <attribute name="certainty">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.normal">
+    <attribute name="normal">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+
+  <!-- typing attributes -->
+  <rng:define name="a.encodinganalog">
+    <attribute name="encodinganalog">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.level">
+    <attribute name="level">
+      <choice>
+        <value>class</value>
+        <value>collection</value>
+        <value>file</value>
+        <value>fonds</value>
+        <value>item</value>
+        <value>otherlevel</value>
+        <value>recordgrp</value>
+        <value>series</value>
+        <value>subfonds</value>
+        <value>subgrp</value>
+        <value>subseries</value>
+      </choice>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.localtype">
+    <attribute name="localtype">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.relatedencoding">
+    <attribute name="relatedencoding">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.unitdatetype">
+    <optional>
+      <attribute name="unitdatetype">
+        <choice>
+          <value>bulk</value>
+          <value>inclusive</value>
+        </choice>
+      </attribute>
+    </optional>
+  </rng:define>
+  <!-- table attributes -->
+  <rng:define name="a.char">
+    <attribute name="char">
+      <data type="token"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.charoff">
+    <attribute name="charoff">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.colname">
+    <attribute name="colname">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.colsep">
+    <attribute name="colsep">
+      <ref name="av.boolean"/>
+    </attribute>
+  </rng:define>
+  <rng:define name="a.rowsep">
+    <attribute name="rowsep">
+      <ref name="av.boolean"/>
+    </attribute>
+  </rng:define>
+  <!-- other attributes -->
+  <rng:define name="a.coverage">
+    <attribute name="coverage">
+      <choice>
+        <value>whole</value>
+        <value>part</value>
+      </choice>
+    </attribute>
+  </rng:define>
+  <rng:define name="am.countrycode">
+    <optional>
+      <attribute name="countrycode">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </rng:define>
+  <rng:define name="a.transliteration">
+    <attribute name="transliteration">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </rng:define>
+
+  <!-- ATTRIBUTE VALUE LISTS -->
+  <rng:define name="av.boolean">
+    <choice>
+      <value>true</value>
+      <value>false</value>
+    </choice>
+  </rng:define>
+
+</rng:div></rng:div>
+    <start>
+        <ref name="e.ead"/>
+    </start>
+</grammar>

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,17 @@
 from setuptools import setup, find_packages
 setup(
     name = "eadator",
-    version = "0.3.4",
+    version = "1.0.0-a0",
     packages = find_packages(),
     install_requires = ['lxml', 'argparse'],
     package_data = {
         'eadator': [
-            'ents/*.dtd', 'ents/*.xsd', 'ents/*.xml', 'ents/*.ent', 'ents/*.dcl'
+            'ents/*.dtd',
+            'ents/*.xsd',
+            'ents/*.xml',
+            'ents/*.ent',
+            'ents/*.dcl',
+            'ents/*.rng',
         ],
     },
     zip_safe = False,
@@ -19,7 +24,7 @@ setup(
     license = "BSD",
     keywords = "validate ead 2002 xml xsd dtd",
     url = "https://github.com/eadhost/eadator",   # project home page, if any
-    download_url = "https://github.com/eadhost/eadator/tarball/0.3.4",
+    download_url = "https://github.com/eadhost/eadator/tarball/1.0.0-a0",
     # could also include long_description, download_url, classifiers, etc.
     entry_points = {
         'console_scripts': [
@@ -29,7 +34,7 @@ setup(
     test_suite = "tests.test_eadator"
 )
 
-# Copyright © 2014, Regents of the University of California
+# Copyright © 2015, Regents of the University of California
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     # metadata for upload to PyPI
     author = "Brian Tingle",
     author_email = "brian.tingle.cdlib.org@gmail.com",
-    description = "EAD2002 (DTD or XSD) universal validator",
+    description = "EAD2002 (DTD or XSD) and EAD3 (RNG) universal validator",
     license = "BSD",
     keywords = "validate ead 2002 xml xsd dtd",
     url = "https://github.com/eadhost/eadator",   # project home page, if any

--- a/tests/S.0001_invalid.xml
+++ b/tests/S.0001_invalid.xml
@@ -1,0 +1,1199 @@
+<?xml-model href="../schematron/ead.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../ead3.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<ead xmlns="http://ead3.archivists.org/schema/" relatedencoding="MARC">
+	<control countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b"
+		relatedencoding="iso15511" scriptencoding="iso15924">
+		<recordid instanceurl="http://eadiva.com/hogwarts-ead/S.0001.xml">S.0001</recordid>
+		<otherrecordid localtype="manuscript">Slytherin-S-1</otherrecordid>
+		<representation href="http://ead3.eadiva.com/S0001"
+			linktitle="HTML transformation of the finding aid" show="new"/>
+		<filedesc>
+			<titlestmt>
+				<titleproper>Manuscripts of Salazar Slytherin: Finding Aid</titleproper>
+				<subtitle>A guide to the letters, papers, and spell books held at Hogwarts School of
+					Witchcraft and Wizardry Archives</subtitle>
+				<author>Felicia Flitwick</author>
+				<sponsor>Funding for the initial creation of this electronic finding aid was made
+					possible in 1992 by a generous gift of Slytherin's class of 1972. Funding for
+					encoding was made possible in 2008 by a gift from Slytherin's class of
+					1998.</sponsor>
+			</titlestmt>
+			<editionstmt>
+				<edition>2nd edition</edition>
+				<p>Edition was updated during EAD3 encoding to conform to DACS standards.</p>
+			</editionstmt>
+			<publicationstmt>
+				<publisher>Hogwarts School of Witchcraft and Wizardry</publisher>
+				<date normal="2014-03-01">1 March 2014</date>
+				<address>
+				<addressline>Hogwarts School of Witchcraft and Wizardry, Archives</addressline>
+				<addressline>Hogwarts Castle</addressline>
+				<addressline>Inverness IV27 H64</addressline>
+				<addressline>Scotland, UK</addressline>
+				<addressline>+44 01549 511100</addressline>
+				<addressline>archivist@hogwarts.ac.uk</addressline>
+			</address>
+			</publicationstmt>
+			<seriesstmt>
+				<titleproper>Manuscripts of the Founders of Hogwarts School of Witchcraft and
+					Wizardry</titleproper>
+				<num>4</num>
+			</seriesstmt>
+			<notestmt>
+				<controlnote>
+					<p>The archivist is aware that certain families who came up through Slytherin
+						still possess original documents and realia from the house's founder. Please
+						consider donating or bequeathing these to our archives so that we may
+						present Salazar Slytherin's life and views more completely.</p>
+				</controlnote>
+			</notestmt>
+		</filedesc>
+		<maintenancestatus value="revised"/>
+		<publicationstatus value="published"/>
+		<maintenanceagency>
+			<agencycode>ST-In-HSWWA</agencycode>
+			<otheragencycode localtype="wizlib">H</otheragencycode>
+			<agencyname>Hogwarts School of Witchcraft and Wizardry Archives</agencyname>
+		</maintenanceagency>
+		<languagedeclaration>
+			<language langcode="eng">English</language>
+			<script scriptcode="latn">Latin</script>
+		</languagedeclaration>
+		<conventiondeclaration>
+			<abbr>DACS</abbr>
+			<citation href="http://www2.archivists.org/standards/DACS"
+				lastdatetimeverified="2014-03-01T16:30:21Z" linktitle="DACS in HTML on SAA website"
+				actuate="onload" show="new">Describing Archives: a Content Standard</citation>
+			<descriptivenote>
+				<p>DACS was used as the primary description standard.</p>
+			</descriptivenote>
+		</conventiondeclaration>
+		<localtypedeclaration>
+			<abbr>wizlib</abbr>
+			<citation href="http://eadiva.com/wizlib" linktitle="WizLib Standards" actuate="onload"
+				show="new">Standards for Wizarding Libraries and Archives: 2012</citation>
+			<descriptivenote>
+				<p>The 2012 edition of the Standards for Wizarding Libraries and Archives was used
+					to handle descriptions specific to the wizarding world, such as the Wizarding
+					Agency Code.</p>
+			</descriptivenote>
+		</localtypedeclaration>
+		<localcontrol localtype="house">
+			<term>Slytherin</term>
+		</localcontrol>
+		<localcontrol localtype="section">
+			<term>Restricted</term>
+		</localcontrol>
+		<maintenancehistory>
+			<maintenanceevent>
+				<eventtype value="derived"/>
+				<eventdatetime standarddatetime="2014-03-01T08:05:33Z">1 March 2014</eventdatetime>
+				<agenttype value="machine"/>
+				<agent>Computer</agent>
+				<eventdescription>Conversion from EAD 2002 finding aid using XSL
+					transformation.</eventdescription>
+			</maintenanceevent>
+			<maintenanceevent>
+				<eventtype value="revised"/>
+				<eventdatetime standarddatetime="2014-03-01T10:05:23Z">1 March 2014</eventdatetime>
+				<agenttype value="human"/>
+				<agent>Felicia Flitwick</agent>
+				<eventdescription>Conversion from EAD 2002 revised.</eventdescription>
+			</maintenanceevent>
+			<maintenanceevent>
+				<eventtype value="revised"/>
+				<eventdatetime standarddatetime="2014-03-09T14:23:42">9 March 2014</eventdatetime>
+				<agenttype value="human"/>
+				<agent>Felicia Flitwick</agent>
+				<eventdescription>Minor revisions.</eventdescription>
+			</maintenanceevent>
+		</maintenancehistory>
+		<sources>
+			<source>
+				<sourceentry>Hogwarts: a History</sourceentry>
+				<objectxmlwrap>
+					<oai_dc:dc xmlns:dc="http://purl.org/DC/elements/1.0/"
+						xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+						<dc:title>Hogwarts: a History</dc:title>
+						<dc:creator>Bathilda Bagshot</dc:creator>
+						<dc:date>1968</dc:date>
+						<dc:identifier>DA880.B34 1968</dc:identifier>
+					</oai_dc:dc>
+					<!--
+					<oai_dc:dc xmlns:dc="http://purl.org/DC/elements/1.0/"
+						xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+						<dc:title>Hogwarts: a History</dc:title>
+						<dc:creator>Bathilda Bagshot</dc:creator>
+						<dc:date>1968</dc:date>
+						<dc:identifier>DA880.B34 1968</dc:identifier>
+					</oai_dc:dc>
+					-->
+				</objectxmlwrap>
+				<descriptivenote>
+					<p>Basic biographical and historical information was taken from <title>
+							<part>Hogwarts: a History</part>
+						</title>.</p>
+				</descriptivenote>
+			</source>
+		</sources>
+	</control>
+	<archdesc level="collection">
+		<did>
+			<unittitle>Manuscripts of Salazar Slytherin</unittitle>
+			<unitid>S.0001</unitid>
+			<unitdate normal="0950/1100" certainty="circa" unitdatetype="inclusive"
+				>0950-1100</unitdate>
+			<unitdatestructured certainty="circa" unitdatetype="inclusive">
+				<daterange>
+					<fromdate notafter="0950" standarddate="0950">materials may slightly pre-date
+						0950</fromdate>
+					<todate notafter="1100" standarddate="1100">1100</todate>
+				</daterange>
+			</unitdatestructured>
+			<origination>
+				<persname encodinganalog="100" relator="creator" rules="wizlib">
+					<part>Slytherin</part>
+					<part>Salazar</part>
+					<part>d. circa 1100</part>
+				</persname>
+			</origination>
+			<physdesc>5 linear feet: 38 scrolls, 4 journals, 139 letters, 5 spell books</physdesc>
+			<physdescstructured coverage="whole" physdescstructuredtype="spaceoccupied">
+				<quantity>5</quantity>
+				<unittype>linear feet</unittype>
+			</physdescstructured>
+			<physdescset>
+				<physdescstructured coverage="part" physdescstructuredtype="materialtype">
+					<quantity approximate="false">38</quantity>
+					<unittype>scrolls</unittype>
+					<physfacet>Original scrolls are written in iron gall ink.</physfacet>
+					<dimensions localtype="width" unit="inches">18</dimensions>
+				</physdescstructured>
+				<physdescstructured coverage="part" physdescstructuredtype="materialtype">
+					<quantity approximate="false">4</quantity>
+					<unittype>journals</unittype>
+					<physfacet localtype="binding">Rough, amateur binding. Delicate.</physfacet>
+					<descriptivenote>
+						<p>Original journals appear to have been made by an amateur, possibly
+							Slytherin himself. The binding work is much rougher than on the spell
+							books and they must be handled with care.</p>
+					</descriptivenote>
+				</physdescstructured>
+				<physdescstructured coverage="part" physdescstructuredtype="materialtype">
+					<quantity approximate="false">139</quantity>
+					<unittype>letters</unittype>
+				</physdescstructured>
+				<physdescstructured coverage="part" physdescstructuredtype="materialtype">
+					<quantity approximate="false">5</quantity>
+					<unittype source="wizlib">spell books</unittype>
+					<physfacet localtype="binding">Original spell books are hand-stitched in common
+						leather with raised bands.</physfacet>
+				</physdescstructured>
+			</physdescset>
+			<physloc>Use copies of the materials are located in the Hogwarts Library reading room
+				vault. Originals are stored in a secure location.</physloc>
+			<repository>
+				<corpname normal="Hogwarts School of Witchcraft and Wizardry, Archives"
+					rules="wizlib"
+					source="http://harrypotter.wikia.com/wiki/Hogwarts_School_of_Witchcraft_and_Wizardry">
+					<part>Hogwarts School of Witchcraft and Wizardry</part>
+					<part>Archives</part>
+				</corpname>
+			</repository>
+		</did>
+		<accessrestrict>
+			<head>Restrictions on Access</head>
+			<p>Access to the materials is restricted to the following persons:</p>
+			<list listtype="deflist">
+				<listhead>
+					<head01>Category</head01>
+					<head02>Access level</head02>
+				</listhead>
+				<defitem>
+					<label>Students: Year 5 and above</label>
+					<item>With permission of a professor, students Year 5 and above may do
+						historical research on letters and journals included in the
+						collection.</item>
+				</defitem>
+				<defitem>
+					<label>Slytherin alumni</label>
+					<item>All materials, except spell books. Use of spell books requires approval
+						from the headmaster and archivist.</item>
+				</defitem>
+				<defitem>
+					<label>Hogwarts faculty and administration</label>
+					<item>All materials.</item>
+				</defitem>
+				<defitem>
+					<label>Researchers: Hogwarts alumni</label>
+					<item>Alumni of other Hogwarts houses must obtain approval from the archivist.
+						Use of spell books requires additional approval from the headmaster.</item>
+				</defitem>
+				<defitem>
+					<label>Researchers: Other</label>
+					<item>Researchers who graduated from other magical academies must obtain
+						permission from the Bloody Baron to use Salazar Slytherin's materials. They
+						must then obtain approval for their project's research topics from the
+						archivist. Use of spell books requires additional approval from the
+						headmaster.</item>
+				</defitem>
+			</list>
+		</accessrestrict>
+		<accruals>
+			<head>Accruals to the Collection</head>
+			<p>There are no accruals anticipated for this collection. However, materials are
+				occasionally donated by families with strong Slytherin ties.</p>
+		</accruals>
+		<acqinfo>
+			<head>Acquisition History</head>
+			<p>Correspondence with the Hogwarts founders and some teaching materials came to the
+				library directly after Salazar Slytherin's departure from Hogwarts. The acquisitoins
+				of other materials are addressed at their component level.</p>
+		</acqinfo>
+		<altformavail>
+			<head>Copies for Use</head>
+			<p>The materials have been carefully preserved, but researchers are encouraged to use
+				the copies which have been created over the past two hundred years unless their
+				research requires the originals. Use copies are available for all materials except
+				the spell books and will be used to fill research requests unless the originals are
+				specifically requested and the request is approved.</p>
+		</altformavail>
+		<appraisal>
+			<head>Appraisal of Materials</head>
+			<p>New items are appraised by comparison with Salazar Slytherin's handwriting, then the
+				materials are magically dated. All items determined to be authentic are added to the
+				collection. Donated materials connected to Slytherin (e.g. letters concerning
+				Slytherin, materials from his heirs, etc.) are assessed for their evidentiary value.
+				If they're considered sufficiently valuable, those materials will form their own
+				collection.</p>
+		</appraisal>
+		<arrangement>
+			<head>Arrangement of the Materials</head>
+			<p>Exact chronology of the materials cannot be established due to a lack of dates on any
+				items. Materials are arranged by type, then by deduced chronological order and/or
+				topic.</p>
+		</arrangement>
+		<bibliography>
+			<head>Works Citing the Collection</head>
+			<bibref>Bagshot, Bathilda. <title render="italic">
+					<part>Hogwarts: a History</part>
+				</title>.<date normal="1968">1968</date>, <ref
+					href="http://catalog.hogwarts.ac.uk/record=b11725882" show="new"
+					actuate="onrequest">Catalog record for <title>
+						<part>Hogwarts: a History</part>
+					</title></ref>.</bibref>
+			<bibref>Lestrange, Marius. <title>
+					<part>"An re-examination of Salazar Slytherin's role in English wizarding
+						marriages"</part>
+				</title>. Wizarding Studies Quarterly 51:3 (<date normal="2010-09">September
+					2010</date>): 384-443.</bibref>
+			<bibref>Malfoy, Elizabeth. <title render="italic">
+					<part>A biography of Salazar Slytherin</part>
+					<part>: England's greatest wizard</part>
+				</title><date normal="1843">1843</date>. <ref
+					href="http://catalog.hogwarts.ac.uk/record=b11727364" show="new"
+					actuate="onrequest">Catalog record for <title>
+						<part>A biography of Salazar Slytherin</part>
+						<part>: England's greatest wizard</part>
+					</title></ref>.</bibref>
+		</bibliography>
+		<bioghist>
+			<head>Biography of Salazar Slytherin</head>
+			<p>Salazar Slytherin was born in the first half of the tenth century, somewhere in
+				fen-country England. Researchers believe it was likely Norfolk, Lincolnshire, or
+				Cambridgeshire, but may have been a connected county. He came from a family of
+				pure-blood wizards, although the names of his parents are not recorded. It is
+				unknown whether he trained at a school of the time, at home, or under a master.
+				Together with Gryffindor, Ravenclaw, and Hufflepuff, he founded the <expan
+					abbr="HSWW">Hogwarts School of Witchcraft and Wizardry</expan>.</p>
+			<p>At Hogwarts, Slytherin taught Legilimency, the magical art of forming a mental
+				connection with another's mind and extracting information or interacting with their
+				thought processes. This may have been a genetic talent, as his descendent, Tom
+				Riddle, was also a noted legilimens. Slytherin was also a Parselmouth, a known genet
+				ic trait, and able to speak with snakes. He bred at least one basilisk, which he
+				left at Hogwarts in the Chamber of Secrets. The Chamber remained unopened until
+				1943, when Riddle opened it and used the basilisk to attack Muggle-borns. The
+				basilisk was not killed until 1993.</p>
+			<p>Slytherin believed that the school should only teach pure-blood students and should
+				definitely not accept students whose parents were both Muggles. His own house,
+				Slytherin, continued this tradition, but the other founders overruled him. After an
+				argument with Godric Gryffindor, which may have involved a duel, Slytherin left the
+				school.</p>
+			<p>While it is not known when or where Slytherin died, one of his spell books and a
+				final journal were recovered shortly before the turn of the twelfth century by
+				Slytherin alumnus and professor Albert Shallowheart. It is assumed that Slytherin
+				was dead when these books were recovered.</p>
+		</bioghist>
+		<controlaccess>
+			<persname encodinganalog="600" relator="creator" rules="wizlib"
+				source="http://harrypotter.wikia.com/wiki/Salazar_Slytherin">
+				<part localtype="surname">Slytherin</part>
+				<part localtype="forename">Salazar</part>
+				<part localtype="dates">d. circa 1100</part>
+			</persname>
+			<famname normal="Slytherin family" rules="wizlib"
+				source="http://harrypotter.wikia.com/wiki/Slytherin_family">
+				<part>Slytherin family</part>
+			</famname>
+			<corpname encodinganalog="610" normal="Hogwarts School of Witchcraft and Wizardry"
+				rules="wizlib"
+				source="http://harrypotter.wikia.com/wiki/Hogwarts_School_of_Witchcraft_and_Wizardry">
+				<part>Hogwarts School of Witchcraft and Wizardry</part>
+			</corpname>
+			<subject encodinganalog="650" normal="Magical History, 11th century" rules="wizlib">
+				<part>Magical History</part>
+				<part>11th century</part>
+			</subject>
+			<genreform encodinganalog="655" normal="Spell books" rules="wizlib">
+				<part>Spell books</part>
+			</genreform>
+			<genreform encodinganalog="655" normal="Diaries" rules="wizlib">
+				<part>Diaries</part>
+			</genreform>
+			<genreform encodinganalog="655" normal="Letters" rules="wizlib">
+				<part>Letters</part>
+			</genreform>
+			<geogname encodinganalog="651" rules="wizlib">
+				<part>Great Britain</part>
+				<part>11th century</part>
+			</geogname>
+			<occupation encodinganalog="656" rules="wizlib">
+				<part>Professor</part>
+				<part>Hogwarts School of Witchcraft and Wizardry</part>
+			</occupation>
+		</controlaccess>
+		<custodhist>
+			<head>Custodial History</head>
+			<p>Correspondence with the Hogwarts founders and some teaching materials came to the
+				library directly after Salazar Slytherin's departure from Hogwarts. The custodial
+				history of later acquisitions is listed in their component information.</p>
+		</custodhist>
+		<legalstatus>
+			<head>Legal Status of the Materials</head>
+			<p>In compliance with British Ministry of Magic Statute 38, regulating the distribution
+				of spell books, the Hogwarts reading room imposes special restrictions for the
+				access and use of spell books in the collection. Reproduction is entirely
+				prohibited. All other items fall under magical and muggle public domain laws.</p>
+		</legalstatus>
+		<otherfindaid>
+			<head>Other Finding Aid</head>
+			<p>An original description of this collection is available as a scroll in the Hogwarts
+				reading room. This finding aid is incomplete, but may be of use for researchers who
+				wish to view the contents list of the original collection.</p>
+		</otherfindaid>
+		<phystech>
+			<head>Physical Notes</head>
+			<p>Original scrolls and books have brittle edges, which restricts their use.</p>
+		</phystech>
+		<prefercite>
+			<head>Citation Guide</head>
+			<p>Please cite materials as follows:</p>
+			<p>Description or identification of item; date, if known; Manuscripts of Salazar
+				Slytherin (S.0001). Hogwarts School of Witchcraft and Wizardry Archives.</p>
+		</prefercite>
+		<processinfo>
+			<head>Processing Information</head>
+			<p>The original collection was accessioned and processed on an uncertain date, around
+					<date normal="1100" certainty="circa">1100 CE</date>. As archivists have added
+				to it over the centuries, each has added their own style to its arrangement and
+				description. Most recent processing and description was done by Winifred Pardol in
+				1992 when creating the first version of this finding aid.</p>
+		</processinfo>
+		<relatedmaterial>
+			<head>Related material</head>
+			<p>The Hogwarts Archives holds the materials of the school's other three founders. These
+				papers, particularly the letters, may prove useful in giving context to Slytherin's
+				writings.</p>
+			<archref>Series: <title>
+					<part>Manuscripts of the Founders of Hogwarts School of Witchcraft and
+						Wizardry</part>
+				</title>
+				<num>1</num>. <ref href="http://eadiva.com/hogwarts-ead/G.0001.xml" show="new"
+					actuate="onrequest">Manuscripts of Godric Gryffindor: Finding Aid</ref>
+			</archref>
+			<archref>Series: <title>
+					<part>Manuscripts of the Founders of Hogwarts School of Witchcraft and
+						Wizardry</part>
+				</title>
+				<num>2</num>. <ref href="http://eadiva.com/hogwarts-ead/H.0001.xml" show="new"
+					actuate="onrequest">Manuscripts of Helga Hufflepuff: Finding Aid</ref>
+			</archref>
+			<archref>Series: <title>
+					<part>Manuscripts of the Founders of Hogwarts School of Witchcraft and
+						Wizardry</part>
+				</title>
+				<num>3</num>. <ref href="http://eadiva.com/hogwarts-ead/R.0001.xml" show="new"
+					actuate="onrequest">Manuscripts of Rowena Ravenclaw: Finding Aid</ref>
+			</archref>
+		</relatedmaterial>
+		<relations>
+			<relation id="hhuf" relationtype="cpfrelation" actuate="onrequest" show="new"
+				href="http://eadiva.com/hogwarts-cpf/H.001.xml">
+				<relationentry>Hufflepuff, Helga</relationentry>
+				<descriptivenote>
+					<p>Co-founder of Hogwarts School of Witchcraft and Wizardry. While not the most
+						combative, her acceptance of all students willing to learn was the most at
+						odds with Slytherin's pure blood philosophy.</p>
+				</descriptivenote>
+			</relation>
+			<relation id="ggry" relationtype="cpfrelation" actuate="onrequest" show="new"
+				href="http://eadiva.com/hogwarts-cpf/G.001.xml">
+				<relationentry>Gryffindor, Godric</relationentry>
+				<descriptivenote>
+					<p>Co-founder of Hogwarts School of Witchcraft and Wizardry. Initially a good
+						friend and correspondent of Salazar Slytherin, Gryffindor later cut ties
+						over their disagreement concerning acceptance of muggle-born students.</p>
+				</descriptivenote>
+			</relation>
+			<relation id="rrav" relationtype="cpfrelation" actuate="onrequest" show="new"
+				href="http://eadiva.com/hogwarts-cpf/R.001.xml">
+				<relationentry>Ravenclaw, Rowena</relationentry>
+				<descriptivenote>
+					<p>Co-founder of Hogwarts School of Witchcraft and Wizardry.</p>
+				</descriptivenote>
+			</relation>
+		</relations>
+		<scopecontent>
+			<head>Scope and Content of the Collection</head>
+			<p>The collection is organized into four series:</p>
+			<p><emph render="bold">Series 1: Correspondence with Hogwarts Founders</emph> is
+				correspondence with the Hogwarts founders. It includes Slytherin's letters to Godric
+				Gryffindor, Helga Hufflepuff, and Rowena Ravenclaw. The collection consists
+				exclusively of Slytherin's letters to the founders, not their responses.</p>
+			<p><emph render="bold">Series 2: Other Correspondence</emph> is Slytherin's
+				correspondence with other witches and wizards. It includes letters received by
+				Slytherin and left at Hogwarts on his departure as well as some letters which were
+				donated later on by correspondents.</p>
+			<p><emph render="bold">Series 3: Class Notes</emph> consists of Slytherin's notes for
+				teaching classes on Legilimency, Charms, and Care of Magical Creatures.</p>
+			<p><emph render="bold">Series 4: Journals</emph> is made up of four journals kept by
+				Slytherin from around the time of Hogwarts' founding until shortly before his
+				death.</p>
+			<p><emph render="bold">Series 3: Spell Books</emph> consists of five spell books kept by
+				Slytherin to record jinxes, dark charms, legilimency, spells for the control of
+				basilisks, and the darkest arts.</p>
+		</scopecontent>
+		<separatedmaterial>
+			<head>Separated Material</head>
+			<p>During the <subject rules="wizlib"
+					source="http://harrypotter.wikia.com/wiki/First_Wizarding_War"
+					normal="Wizarding War, 1970-1981">
+					<part>First Wizarding War</part>
+					<part>1970-1981</part>
+				</subject>, a group of <corpname rules="wizlib"
+					source="http://harrypotter.wikia.com/wiki/Death_Eaters">
+					<part>Knights of Walpurgis</part>
+					<part>(Death Eaters)</part>
+				</corpname> stole Syltherin realia from its library display. Known items stolen were
+				Salazar Slytherin's signet ring, a painting (circa 1500) of Slytherin's ancestral
+				home, a ceremonial dagger belonging to Slytherin, and an enchanted 11th century
+				numismatic collection. Use copies of spell books in the archival collection were
+				also taken and had to be recreated. The original Slytherin papers were in the vault,
+				which had been protected by a Disillusionment Charm.</p>
+		</separatedmaterial>
+		<userestrict>
+			<head>Restrictions on Use of Materials</head>
+			<p>Restrictions on are predicated on the researcher already having passed the
+				restrictions on access.</p>
+			<table frame="all" colsep="1" rowsep="1">
+				<tgroup align="center" cols="3">
+					<colspec colname="materialtype" colnum="1"/>
+					<colspec colname="usepermitted" colnum="2"/>
+					<colspec colname="permissionrequired" colnum="3"/>
+					<thead valign="middle">
+						<row>
+							<entry colname="materialtype">Material Type</entry>
+							<entry colname="usepermitted">Use Type</entry>
+							<entry colname="permissionrequired">Permission Required</entry>
+						</row>
+					</thead>
+					<tbody valign="middle">
+						<row>
+							<entry colname="materialtype">Journals</entry>
+							<entry colname="usepermitted">Personal notes</entry>
+							<entry colname="permissionrequired">none required</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Journals</entry>
+							<entry colname="usepermitted">Publication</entry>
+							<entry colname="permissionrequired">Archivist</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Letters</entry>
+							<entry colname="usepermitted">Personal notes</entry>
+							<entry colname="permissionrequired">none required</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Letters</entry>
+							<entry colname="usepermitted">Publication</entry>
+							<entry colname="permissionrequired">Archivist</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Class notes</entry>
+							<entry colname="usepermitted">Personal notes</entry>
+							<entry colname="permissionrequired">Archivist</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Class notes</entry>
+							<entry colname="usepermitted">Publication</entry>
+							<entry colname="permissionrequired">Archivist and Headmaster</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Spell books</entry>
+							<entry colname="usepermitted">Personal notes</entry>
+							<entry colname="permissionrequired">Archivist and Headmaster</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Spell books</entry>
+							<entry colname="usepermitted">Publication</entry>
+							<entry colname="permissionrequired">Not permitted</entry>
+						</row>
+					</tbody>
+				</tgroup>
+			</table>
+		</userestrict>
+		<dsc>
+			<c level="series">
+				<did>
+					<unittitle>Correspondence with Hogwarts Founders</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0975">975</fromdate>
+							<todate notafter="1050">1050</todate>
+						</daterange>
+					</unitdatestructured>
+					<container containerid="SL0001.01" localtype="box">1</container>
+					<!-- commenting out to make valid 
+						bug in current version of the schema: containerid not of type ID					
+						<container parent="SL0001.01" localtype="folders">1-11</container> -->
+					<container localtype="folders">1-11</container>
+
+					<physdesc>84 letters</physdesc>
+				</did>
+				<controlaccess>
+					<genreform encodinganalog="655" rules="wizlib">
+						<part>Letters</part>
+					</genreform>
+					<persname encodinganalog="600" normal="Gryffindor, Godric" rules="wizlib"
+						source="http://eadiva.com/hogwarts-cpf/G.001.xml">
+						<part>Godric Gryffindor</part>
+					</persname>
+					<persname encodinganalog="600" normal="Hufflepuff, Helga" rules="wizlib"
+						source="http://eadiva.com/hogwarts-cpf/H.001.xml">
+						<part>Helga Hufflepuff</part>
+					</persname>
+					<persname encodinganalog="600" normal="Ravenclaw, Rowena" rules="wizlib"
+						source="http://eadiva.com/hogwarts-cpf/R.001.xml">
+						<part>Rowena Ravenclaw</part>
+					</persname>
+				</controlaccess>
+				<arrangement>
+					<head>Arrangement</head>
+					<p>Letters are arranged alphabetically by recipient's last name.</p>
+				</arrangement>
+				<scopecontent>
+					<head>Scope and Contents</head>
+					<p>The letters consist of correspondence with Slytherin's fellow founders of
+						Hogwarts. They cover topics from administrative matters to plans for
+						developing the curriculum to discussion of their respective families. The
+						letters appear to begin around the time of the founding of Hogwarts and
+						continue until Slytherin's departure.</p>
+				</scopecontent>
+				<index>
+					<head>Index of Correspondents</head>
+					<indexentry>
+						<persname normal="Gryffindor, Godric" rules="wizlib"
+							source="hhttp://eadiva.com/hogwarts-cpf/G.001.xml">
+							<part>Godric Gryffindor</part>
+						</persname>
+						<ptrgrp>
+							<ref show="new" actuate="onrequest"
+								href="http://eadiva.com/hogwarts-cpf/G.001.xml">Biographical and
+								Relational Information</ref>
+							<ptr target="ggry" show="replace" actuate="onrequest"
+								linktitle="Relationship to Salazar Slytherin"/>
+						</ptrgrp>
+					</indexentry>
+					<indexentry>
+						<persname normal="Hufflepuff, Helga" rules="wizlib"
+							source="http://eadiva.com/hogwarts-cpf/H.001.xml">
+							<part>Helga Hufflepuff</part>
+						</persname>
+						<ptrgrp>
+							<ref show="new" actuate="onrequest"
+								href="http://eadiva.com/hogwarts-cpf/H.001.xml">Biographical and
+								Relational Information</ref>
+							<ptr target="hhuf" show="replace" actuate="onrequest"
+								linktitle="Relationship to Salazar Slytherin"/>
+						</ptrgrp>
+					</indexentry>
+					<indexentry>
+						<persname normal="Ravenclaw, Rowena" rules="wizlib"
+							source="http://eadiva.com/hogwarts-cpf/G.001.xml">
+							<part>Rowena Ravenclaw</part>
+						</persname>
+						<ptrgrp>
+							<ref show="new" actuate="onrequest"
+								href="http://eadiva.com/hogwarts-cpf/R.001.xml">Biographical and
+								Relational Information</ref>
+							<ptr target="rrav" show="replace" actuate="onrequest"
+								linktitle="Relationship to Salazar Slytherin"/>
+						</ptrgrp>
+					</indexentry>
+				</index>
+				<acqinfo>
+					<head>Acquisitions Information</head>
+					<p>These letters were donated by the three remaining Hogwarts founders shortly
+						after Slytherin left the school. Their letters to him can be found in their
+						respective collections.</p>
+				</acqinfo>
+				<otherfindaid>
+					<head>Other Finding Aid</head>
+					<p>In 1965, as part of her research for <title render="italic">
+							<part>Hogwarts: A History</part>
+						</title>, Bathilda Bagshot created an index of letters between Hogwarts
+						founders based on subject and occasional date information. Each entry
+						contains a brief summary of the letter's context and contents. A copy of
+						this index is available for researchers. It was also used to create <ref
+							href="http://catalog.hogwarts.ac.uk/record=b11713487" show="new"
+							actuate="onrequest"><title render="italic">
+								<part>Correspondence of the Hogwarts Founders</part>
+							</title></ref>, see <ptr target="ah876"
+							linktitle="Alternate Form Available" show="replace" actuate="onrequest"
+						/> for further details.</p>
+				</otherfindaid>
+				<altformavail id="ah876">
+					<head>Alternate Form Available</head>
+					<p>In 1972, Balthilda Bagshot published <title render="italic">
+							<part>Correspondence of the Hogwarts Founders</part>
+						</title>, full transcriptions of the letters between Salazar Slytherin,
+						Godric Gryffindor, Helga Hufflepuff, and Rowena Ravenclaw. This book may
+						prove more helpful to researchers than reading Slytherin's letters alone. It
+						is available in the <ref
+							href="http://catalog.hogwarts.ac.uk/record=b11713487" show="new"
+							actuate="onrequest">main Hogwarts library</ref>.</p>
+				</altformavail>
+			</c>
+			<c level="series">
+				<did>
+					<unittitle>Other Correspondence</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0975">975</fromdate>
+							<todate notafter="1050">1050</todate>
+						</daterange>
+					</unitdatestructured>
+					<container containerid="SL0001.02" localtype="box">2</container>
+					<container localtype="folders">12-18</container>
+					<!-- commenting out to make valid 
+						bug in current version of the schema: containerid not of type ID
+					<container parent="SL0001.02" localtype="folders">12-18</container>
+					-->
+					<physdesc>55 letters</physdesc>
+				</did>
+				<controlaccess>
+					<genreform encodinganalog="655" rules="wizlib">
+						<part>Letters</part>
+					</genreform>
+				</controlaccess>
+				<arrangement>
+					<head>Arrangement</head>
+					<p>Letters are arranged alphabetically by correspondent's last name.</p>
+				</arrangement>
+				<scopecontent>
+					<head>Scope and Content</head>
+					<p>All correspondence with people other than Hogwarts founders. May contain
+						letters both two and from Slytherin.</p>
+					<list listtype="deflist">
+						<listhead>
+							<head01>Correspondent</head01>
+							<head02>Description/Relationship</head02>
+						</listhead>
+						<defitem>
+							<label>Lavinia Black</label>
+							<item>Hogwarts professor of runes</item>
+						</defitem>
+						<defitem>
+							<label>Belle Jouliet</label>
+							<item>French witch</item>
+						</defitem>
+						<defitem>
+							<label>Marcus Malfoy</label>
+							<item>Hogwarts professor of Ghoul Studies</item>
+						</defitem>
+						<defitem>
+							<label>Phineas Peverell</label>
+							<item>Hogwarts professor of potions</item>
+						</defitem>
+						<defitem>
+							<label>Morgul Scadamer</label>
+							<item>Wizard and childhood friend</item>
+						</defitem>
+					</list>
+				</scopecontent>
+			</c>
+			<c level="series">
+				<did>
+					<unittitle>Class Notes</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0975">975</fromdate>
+							<todate notafter="1050">1050</todate>
+						</daterange>
+					</unitdatestructured>
+					<physdesc>38 scrolls</physdesc>
+					<container localtype="scrollboxes">1-38</container>
+					<didnote>The archives currently holds scrolls with class notes for Slytherin's
+						classes on legilimency, charms, and care of magical creatures. Tradition
+						holds that he taught a class on alchemy as well.</didnote>
+				</did>
+				<scopecontent>
+					<head>Scope and Content</head>
+					<p>This series consists of scrolls on which Slytherin recorded notes for the
+						teaching legilimency, charms, and care of magical creatures. Notes include
+						references to many books which no longer exist, lists of class topics, and
+						detailed notes on the subjects. Many researchers find these useful for
+						deriving an impression of Slytherin's teaching philosophy and
+						priorities.</p>
+				</scopecontent>
+				<c level="file">
+					<did>
+						<unittitle>Class Notes for Legilimency</unittitle>
+						<physdesc>22 scrolls</physdesc>
+						<container localtype="scrollboxes">1-22</container>
+					</did>
+					<controlaccess>
+						<function encodinganalog="657" rules="wizlib">
+							<part>Magical instruction</part>
+						</function>
+						<genreform encodinganalog="655" rules="wizlib">
+							<part>Teaching materials</part>
+						</genreform>
+						<subject encodinganalog="650" rules="wizlib">
+							<part>Legilimency</part>
+						</subject>
+						<subject encodinganalog="650" rules="wizlib">
+							<part>Restricted magic</part>
+						</subject>
+					</controlaccess>
+					<scopecontent>
+						<head>Scope and Content</head>
+						<p>Slytherin taught extensively on legilimency, over the qualms and informal
+							objections of other houses' founders. These 22 scrolls include class
+							outlines, spell types, instructions for legilimentic dueling, and other
+							materials related to legimency.</p>
+					</scopecontent>
+					<accessrestrict>
+						<head>Restrictions on Access</head>
+						<p>Beyond restrictions to the use of the Class Notes series, the archivist
+							reserves the right to restrict access to this material, as it comes
+							dangerously close to the Dark Arts.</p>
+					</accessrestrict>
+				</c>
+				<c level="file">
+					<did>
+						<unittitle>Class Notes for Charms</unittitle>
+						<physdesc>9 scrolls</physdesc>
+						<container localtype="scrollboxes">23-31</container>
+					</did>
+					<controlaccess>
+						<function encodinganalog="657" rules="wizlib">
+							<part>Magical instruction</part>
+						</function>
+						<genreform encodinganalog="655" rules="wizlib">
+							<part>Teaching materials</part>
+						</genreform>
+						<subject encodinganalog="650" rules="wizlib">
+							<part>Charms</part>
+						</subject>
+					</controlaccess>
+					<scopecontent>
+						<head>Scope and Content</head>
+						<p>These scrolls contain Slytherin's notes for teaching the following
+							charms: <foreign lang="spl" render="italic">Alohomora</foreign>,
+								<foreign lang="spl" render="italic">anti-Alohomora</foreign>,
+								<foreign lang="spl" render="italic">Bombarda</foreign>, <foreign
+								lang="spl" render="italic">Deprimo</foreign>, <foreign lang="spl"
+								render="italic">Dessendium</foreign>, <foreign lang="spl"
+								render="italic">Epoximise</foreign>, <foreign lang="spl"
+								render="italic">Glacius</foreign> (all three forms), <foreign
+								lang="spl" render="italic">Impervius</foreign>, <foreign lang="spl"
+								render="italic">Lacarnum Inflamarae</foreign>, <foreign lang="spl"
+								render="italic">Portaberto</foreign>, <foreign lang="spl"
+								render="italic">Protego</foreign> (multiple forms), <foreign
+								lang="spl" render="italic">Stupefy</foreign> (multiple forms),
+								<foreign lang="spl" render="italic">Verdimillious</foreign>,
+								<foreign lang="spl" render="italic">Waddiwasi</foreign>.</p>
+					</scopecontent>
+					<fileplan>
+						<head>Scroll Contents</head>
+						<p>The charms may be found on the following scrolls:</p>
+						<list listtype="deflist">
+							<defitem>
+								<label>Scroll 1</label>
+								<item><foreign lang="spl" render="italic">Alohomora</foreign>,
+										<foreign lang="spl" render="italic"
+									>anti-Alohomora</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 2</label>
+								<item><foreign lang="spl" render="italic">Bombarda</foreign>,
+										<foreign lang="spl" render="italic">Deprimo</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 3</label>
+								<item><foreign lang="spl" render="italic">Epoximise</foreign>,
+										<foreign lang="spl" render="italic">Glacius</foreign> (all
+									three forms) </item>
+							</defitem>
+							<defitem>
+								<label>Scroll 4</label>
+								<item><foreign lang="spl" render="italic">Stupefy</foreign>
+									(multiple forms)</item>
+							</defitem>
+							<defitem>
+								<label>Scroll 5</label>
+								<item><foreign lang="spl" render="italic">Impervius</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 6</label>
+								<item><foreign lang="spl" render="italic">Lacarnum
+										Inflamarae</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 7</label>
+								<item><foreign lang="spl" render="italic">Dissendium</foreign>,
+										<foreign lang="spl" render="italic"
+									>Portaberto</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 8</label>
+								<item><foreign lang="spl" render="italic">Protego</foreign>
+									(multiple forms)</item>
+							</defitem>
+							<defitem>
+								<label>Scroll 9</label>
+								<item><foreign lang="spl" render="italic">Verdimillious</foreign>,
+										<foreign lang="spl" render="italic"
+									>Waddiwasi</foreign></item>
+							</defitem>
+						</list>
+						<p>Scrolls are not originally numbered. They are ordered based on their
+							aprpoximate alphabetical order.</p>
+					</fileplan>
+				</c>
+				<c level="file">
+					<did>
+						<unittitle>Class Notes for Care of Magical Creatures</unittitle>
+						<physdesc>7 scrolls</physdesc>
+						<container localtype="scrollboxes">32-38</container>
+						<daoset coverage="part">
+							<dao daotype="derived"
+								href="http://eadiva.com/wizlib-files/salamanders.jpg"
+								localtype="portion" show="embed">
+								<descriptivenote>
+									<p>Sample portion of a scroll on the care of salamanders</p>
+								</descriptivenote>
+							</dao>
+							<dao daotype="derived" href="http://eadiva.com/wizlib-files/imps.jpg"
+								localtype="portion" show="embed">
+								<descriptivenote>
+									<p>Sample portion of a scroll on the care of Imps.</p>
+								</descriptivenote>
+							</dao>
+							<descriptivenote>
+								<p>These materials were digitized for the use of professors teaching
+									Care of Magical Creatures. These images are examples of
+									digitized files which may be available to researchers with the
+									archivists' permission. To request a copy, please contact the
+									archivist.</p>
+							</descriptivenote>
+						</daoset>
+					</did>
+					<controlaccess>
+						<function encodinganalog="657" rules="wizlib">
+							<part>Magical instruction</part>
+						</function>
+						<genreform encodinganalog="655" rules="wizlib">
+							<part>Teaching materials</part>
+						</genreform>
+						<subject encodinganalog="650" rules="wizlib">
+							<part>Care of magical creatures</part>
+						</subject>
+					</controlaccess>
+					<index>
+						<head>Index of Animals Described</head>
+						<p>Animals are grouped by class and paired with a link to the official
+							Ministry of Magic magical creature class description.</p>
+						<indexentry>
+							<namegrp>
+								<name>
+									<part>Imp</part>
+								</name>
+								<name>
+									<part>Salamander</part>
+								</name>
+							</namegrp>
+							<ref
+								href="http://regcontrol.ministry.magic.uk/magical-creature-tables/class_1"
+								show="new" actuate="onrequest">Table of Class 1 Creatures</ref>
+						</indexentry>
+						<indexentry>
+							<namegrp>
+								<name>
+									<part>Cockatrice</part>
+								</name>
+								<name>
+									<part>Griffin</part>
+								</name>
+								<name>
+									<part>Thestral</part>
+								</name>
+							</namegrp>
+							<ref
+								href="http://regcontrol.ministry.magic.uk/magical-creature-tables/class_2"
+								show="new" actuate="onrequest">Table of Class 2 Creatures</ref>
+						</indexentry>
+						<indexentry>
+							<name>
+								<part>Basilisk</part>
+							</name>
+							<ref
+								href="http://regcontrol.ministry.magic.uk/magical-creature-tables/class_3"
+								show="new" actuate="onrequest">Table of Class 3 Creatures</ref>
+						</indexentry>
+					</index>
+					<scopecontent>
+						<head>Scope and Content</head>
+						<p>Each scroll contains information on a different type of magical creature.
+							The scrolls include lecture notes, lists of references, and notes about
+							the health and disposition of animals being held for student use.</p>
+					</scopecontent>
+					<altformavail>
+						<head>Alternate Form Available</head>
+						<p>These materials have been digitized for the use of professors teaching
+							Care of Magical Creatures.</p>
+					</altformavail>
+					<odd>
+						<head>Other Information</head>
+						<p>Many researchers are unaware of Slytherin's time as a teacher of the Care
+							of Magical Creatures class. His notes demonstrate a strong affinity with
+							the darker magical creatures and certain letters between Slytherin and
+							Helga Hufflepuff call into question his methods of binding particular
+							creatures to his will.</p>
+					</odd>
+				</c>
+			</c>
+			<c level="series">
+				<did>
+					<unittitle>Journals</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0950">950</fromdate>
+							<todate notafter="1050">1050</todate>
+						</daterange>
+					</unitdatestructured>
+					<physdesc>4 journals</physdesc>
+					<container containerid="SL0001.03" localtype="box">3</container>
+					<abstract> The following are sample passages from Slytherin's journals:<lb/>
+						<quote>Refining <foreign lang="spl" render="italic">Legilimency</foreign>. I
+							believe I have discovered the secret of doing more than parsing thought.
+							I may now twist memories to create visions.</quote>
+						<lb/>
+						<quote>A quarrel today between my students and those mudbloods allowed in by
+							Hufflepuff. It may become necessary to withhold the teaching of <foreign
+								lang="spl" render="italic">Crucio</foreign> until the final year of
+							studies. Hufflepuff has suggested that the matter should be brought
+							before the Wizards' Council and wants to expel young Lucian. I will talk
+							to Godric about instituting an internal court for trials concerning
+							student matters. Expulsion should be a matter of last resort, for if we
+							do not train these bright young talents, they may be vulnerable to
+							Muggle courts and burning.</quote>
+					</abstract>
+				</did>
+				<controlaccess>
+					<genreform encodinganalog="655" rules="wizlib">
+						<part>Journals</part>
+					</genreform>
+				</controlaccess>
+				<scopecontent>
+					<head>Scope and Content</head>
+					<p>The journals are sequential, each covering mundane activities of Slytherin's
+						life. Some days simply record classes or meetings, others have notes with
+						his opinions and thoughts on particular topics. The journals contain <emph
+							render="bolditalic">no</emph> magical content (spells, potion recipes,
+						etc.), although all four include his opinions concerning the use and
+						teaching of magic. The journals begin just before the founding of Hogwarts
+						and continue until shortly past his departure. He appears to have used them
+						primarily to express opinions and to record information for future
+						reference. The final journal was found in a small residence near <geogname>
+							<part>Slackbuie</part>
+							<part>Scotland</part>
+							<geographiccoordinates coordinatesystem="UTM">30V 427400mE
+								6368503mN</geographiccoordinates>
+						</geogname> by professor Albert Shallowheart along with his spell book on
+						jinxes. It only contained 5 entries subsequent to his departure from
+						Hogwarts, none of which gave details about his locations after leaving
+						Hogwarts. <footnote>
+							<p>Over the centuries, many Slytherin faithful have combed the Slackbuie
+								area looking for signs of his presence there. However, if any
+								information has been found, it has not been published or passed down
+								through common lore.</p>
+						</footnote></p>
+				</scopecontent>
+			</c>
+			<c level="series">
+				<did>
+					<unittitle>Spell Books</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0950">950</fromdate>
+							<todate notafter="1100">1100</todate>
+						</daterange>
+					</unitdatestructured>
+					<physdesc>5 spell books</physdesc>
+					<container localtype="boxes">4-5</container>
+					<materialspec>Many spells are encoded in the arcanumscript commonly used by
+						wizards of the time to prevent the information from falling into Muggle
+						hands. A <ref href="http://catalog.hogwarts.ac.uk/record=b11716545"
+							show="new" actuate="onrequest">reference guide to arcanumscript</ref> is
+						available in the Restricted Section of the main Hogwarts library. Please ask
+						the archivist for assistance in finding it.</materialspec>
+					<langmaterial>
+						<languageset>
+							<language langcode="lat">Latin</language>
+							<script scriptcode="zzzz">arcanumscript</script>
+						</languageset>
+					</langmaterial>
+				</did>
+				<scopecontent>
+					<head>List of spell books</head>
+					<list listtype="ordered">
+						<item>Jinxes</item>
+						<item>Dark charms</item>
+						<item>Legilimency</item>
+						<item>Control of basilisks</item>
+						<item>Truest curses</item>
+					</list>
+				</scopecontent>
+				<controlaccess>
+					<genreform encodinganalog="655" rules="wizlib">
+						<part>Spell books</part>
+					</genreform>
+				</controlaccess>
+				<originalsloc audience="internal">
+					<p>All original spell books are stored in the headmaster's office, separately
+						from other original archival materials.</p>
+				</originalsloc>
+				<altformavail>
+					<head>Use Copies Available</head>
+					<p>Original spell books have not been fully reproduced for researcher use.
+						Reproduction of these materials was supervised by Aurors from the <abbr
+							expan="Ministry of Magic">M.o.M</abbr>, who determined that the mere
+						transcription of certain spells might prove dangerous. Researchers wishing
+						to consult the spell books in their entireties must first obtain permission
+						to use original materials from Hogwarts staff, then obtain secondary
+						permission from the Aurors Office to proceed.</p>
+				</altformavail>
+				<acqinfo>
+					<head>Acquisitions Information</head>
+					<chronlist>
+						<chronitem>
+							<datesingle notbefore="1100">circa 1100</datesingle>
+							<chronitemset>
+
+								<event>Slytherin's spell book of jinxes was found by professor <name>
+										<part>Albert Shallowheart</part>
+									</name> in an abandoned residence near <geogname>
+										<part>Slackbuie</part>
+										<part>Scotland</part>
+									</geogname>. He initially intended it for the possession of
+									Slytherin house. However the headmaster confiscated, who added
+									it to Slytherin's materials in the library.</event>
+							</chronitemset>
+						</chronitem>
+
+						<chronitem>
+							<datesingle notbefore="1290">circa 1300</datesingle>
+							<event><persname normal="Peverell, Lucinda" rules="wizlib"
+									relator="donor">
+									<part>Lucinda Peverell</part>
+								</persname>, daughter of <persname rules="wizlib"
+									source="http://harrypotter.wikia.com/wiki/Cadmus_Peverell">
+									<part>Cadamus Peverell</part>
+								</persname>, donated a spell book of dark charms which had been
+								given to her father by Slytherin at some point after his departure
+								from Hogwarts. Her letter accompanying the book noted that it was
+								"prone to muttering" and the headmaster at the time took appropriate
+								steps to shield it.</event>
+						</chronitem>
+						<chronitem>
+							<datesingle notafter="1820">before 1820</datesingle>
+							<event><persname normal="Gaunt, Malachi" rules="wizlib" relator="donor">
+									<part>Malachi Gaunt</part>
+								</persname>, one of the few members of that family to be sorted into
+								Ravenclaw, donated two of Slytherin's spell books, one devoted to
+								legilimency, and one concerning spells to control basilisks and
+								other serpents.</event>
+						</chronitem>
+
+						<chronitem>
+							<dateset>
+								<datesingle standarddate="1924-03">March 1924</datesingle>
+								<daterange>
+									<fromdate standarddate="1924-07">July 1924</fromdate>
+									<todate standarddate="1924-09">September 1924</todate>
+								</daterange>
+							</dateset>
+							<chronitemset>
+
+								<event>When <persname normal="Gaunt, Morfin" rules="wizlib"
+										source="http://harrypotter.wikia.com/wiki/Morfin_Gaunt">
+										<part>Morfin Gaunt</part>
+									</persname> was sentenced to three years in <corpname
+										normal="Azkaban Prison" rules="wizlib"
+										source="http://harrypotter.wikia.com/wiki/Azkaban">
+										<part>Azkaban</part>
+									</corpname>, a spell book of extremely dangerous dark arts was
+									discovered among the belongings he attempted to bring with him.
+									Aurors determined the spell book's creator to be Salazar
+									Slytherin. The book was donated to Hogwarts for exclusive use of
+									headmasters and Defense Against the Dark Arts professors. The
+									spell book has multiple charms intended to alert aurors to
+									unauthorized uses.</event>
+								<event>For nearly three months in 1924, the spell book was
+									temporarily removed from Hogwarts to the Ministry of Magic after
+										<persname normal="Gaunt, Marvolo" rules="wizlib"
+										source="http://harrypotter.wikia.com/wiki/Marvolo_Gaunt">
+										<part>Marvolo Gaunt</part>
+									</persname> launched an unsuccessful appeal for its return to
+									the family as inherited property. The spell book was returned to
+									Hogwarts afterward.</event>
+							</chronitemset>
+						</chronitem>
+
+					</chronlist>
+				</acqinfo>
+				<custodhist>
+					<head>Custodial History</head>
+					<p>Based on the pattern of acquisition, Slytherin's spell books have been passed
+						down through the Peverell and Gaunt families. It seems likely that Slytherin
+						visisted one of more of his children and close friends after his departure
+						from Hogwarts and left his spell books in their charge. By the point of his
+						death, it seems unlikely that he would have had need for consulting
+						reference materials as he was a highly-accomplished wizard. Early archivists
+						speculate that he retained his book of jinxes in order to record new spells
+						and was not able to transmit it to its designated party before his
+						death.</p>
+				</custodhist>
+				<odd>
+					<head>Other Information</head>
+					<p>The archivist cannot provide information on the secret location of the
+						original spell books or the types of spells and charms used to protect them
+						from unauthorized research. Researchers are advised not to waste their time
+						and the archivists' with repeated inquiries.</p>
+				</odd>
+			</c>
+		</dsc>
+	</archdesc>
+</ead>

--- a/tests/S.0001_valid.xml
+++ b/tests/S.0001_valid.xml
@@ -1,0 +1,1200 @@
+<?xml-model href="../schematron/ead.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../ead3.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<ead xmlns="http://ead3.archivists.org/schema/" relatedencoding="MARC">
+	<control countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b"
+		relatedencoding="iso15511" scriptencoding="iso15924">
+		<recordid instanceurl="http://eadiva.com/hogwarts-ead/S.0001.xml">S.0001</recordid>
+		<otherrecordid localtype="manuscript">Slytherin-S-1</otherrecordid>
+		<representation href="http://ead3.eadiva.com/S0001"
+			linktitle="HTML transformation of the finding aid" show="new"/>
+		<filedesc>
+			<titlestmt>
+				<titleproper>Manuscripts of Salazar Slytherin: Finding Aid</titleproper>
+				<subtitle>A guide to the letters, papers, and spell books held at Hogwarts School of
+					Witchcraft and Wizardry Archives</subtitle>
+				<author>Felicia Flitwick</author>
+				<sponsor>Funding for the initial creation of this electronic finding aid was made
+					possible in 1992 by a generous gift of Slytherin's class of 1972. Funding for
+					encoding was made possible in 2008 by a gift from Slytherin's class of
+					1998.</sponsor>
+			</titlestmt>
+			<editionstmt>
+				<edition>2nd edition</edition>
+				<p>Edition was updated during EAD3 encoding to conform to DACS standards.</p>
+			</editionstmt>
+			<publicationstmt>
+				<publisher>Hogwarts School of Witchcraft and Wizardry</publisher>
+				<date normal="2014-03-01">1 March 2014</date>
+				<address>
+				<addressline>Hogwarts School of Witchcraft and Wizardry, Archives</addressline>
+				<addressline>Hogwarts Castle</addressline>
+				<addressline>Inverness IV27 H64</addressline>
+				<addressline>Scotland, UK</addressline>
+				<addressline>+44 01549 511100</addressline>
+				<addressline>archivist@hogwarts.ac.uk</addressline>
+			</address>
+			</publicationstmt>
+			<seriesstmt>
+				<titleproper>Manuscripts of the Founders of Hogwarts School of Witchcraft and
+					Wizardry</titleproper>
+				<num>4</num>
+			</seriesstmt>
+			<notestmt>
+				<controlnote>
+					<p>The archivist is aware that certain families who came up through Slytherin
+						still possess original documents and realia from the house's founder. Please
+						consider donating or bequeathing these to our archives so that we may
+						present Salazar Slytherin's life and views more completely.</p>
+				</controlnote>
+			</notestmt>
+		</filedesc>
+		<maintenancestatus value="revised"/>
+		<publicationstatus value="published"/>
+		<maintenanceagency>
+			<agencycode>ST-In-HSWWA</agencycode>
+			<otheragencycode localtype="wizlib">H</otheragencycode>
+			<agencyname>Hogwarts School of Witchcraft and Wizardry Archives</agencyname>
+		</maintenanceagency>
+		<languagedeclaration>
+			<language langcode="eng">English</language>
+			<script scriptcode="latn">Latin</script>
+		</languagedeclaration>
+		<conventiondeclaration>
+			<abbr>DACS</abbr>
+			<citation href="http://www2.archivists.org/standards/DACS"
+				lastdatetimeverified="2014-03-01T16:30:21Z" linktitle="DACS in HTML on SAA website"
+				actuate="onload" show="new">Describing Archives: a Content Standard</citation>
+			<descriptivenote>
+				<p>DACS was used as the primary description standard.</p>
+			</descriptivenote>
+		</conventiondeclaration>
+		<localtypedeclaration>
+			<abbr>wizlib</abbr>
+			<citation href="http://eadiva.com/wizlib" linktitle="WizLib Standards" actuate="onload"
+				show="new">Standards for Wizarding Libraries and Archives: 2012</citation>
+			<descriptivenote>
+				<p>The 2012 edition of the Standards for Wizarding Libraries and Archives was used
+					to handle descriptions specific to the wizarding world, such as the Wizarding
+					Agency Code.</p>
+			</descriptivenote>
+		</localtypedeclaration>
+		<localcontrol localtype="house">
+			<term>Slytherin</term>
+		</localcontrol>
+		<localcontrol localtype="section">
+			<term>Restricted</term>
+		</localcontrol>
+		<maintenancehistory>
+			<maintenanceevent>
+				<eventtype value="derived"/>
+				<eventdatetime standarddatetime="2014-03-01T08:05:33Z">1 March 2014</eventdatetime>
+				<agenttype value="machine"/>
+				<agent>Computer</agent>
+				<eventdescription>Conversion from EAD 2002 finding aid using XSL
+					transformation.</eventdescription>
+			</maintenanceevent>
+			<maintenanceevent>
+				<eventtype value="revised"/>
+				<eventdatetime standarddatetime="2014-03-01T10:05:23Z">1 March 2014</eventdatetime>
+				<agenttype value="human"/>
+				<agent>Felicia Flitwick</agent>
+				<eventdescription>Conversion from EAD 2002 revised.</eventdescription>
+			</maintenanceevent>
+			<maintenanceevent>
+				<eventtype value="revised"/>
+				<eventdatetime standarddatetime="2014-03-09T14:23:42">9 March 2014</eventdatetime>
+				<agenttype value="human"/>
+				<agent>Felicia Flitwick</agent>
+				<eventdescription>Minor revisions.</eventdescription>
+			</maintenanceevent>
+		</maintenancehistory>
+		<sources>
+			<source>
+				<sourceentry>Hogwarts: a History</sourceentry>
+				<objectxmlwrap>
+					<oai_dc:dc xmlns:dc="http://purl.org/DC/elements/1.0/"
+						xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+						<dc:title>Hogwarts: a History</dc:title>
+						<dc:creator>Bathilda Bagshot</dc:creator>
+						<dc:date>1968</dc:date>
+						<dc:identifier>DA880.B34 1968</dc:identifier>
+					</oai_dc:dc>
+					<!--
+					<oai_dc:dc xmlns:dc="http://purl.org/DC/elements/1.0/"
+						xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+						<dc:title>Hogwarts: a History</dc:title>
+						<dc:creator>Bathilda Bagshot</dc:creator>
+						<dc:date>1968</dc:date>
+						<dc:identifier>DA880.B34 1968</dc:identifier>
+					</oai_dc:dc>
+					-->
+				</objectxmlwrap>
+				<descriptivenote>
+					<p>Basic biographical and historical information was taken from <title>
+							<part>Hogwarts: a History</part>
+						</title>.</p>
+				</descriptivenote>
+			</source>
+		</sources>
+	</control>
+	<archdesc level="collection">
+		<did>
+			<unittitle>Manuscripts of Salazar Slytherin</unittitle>
+			<unitid>S.0001</unitid>
+			<unitdate normal="0950/1100" certainty="circa" unitdatetype="inclusive"
+				>0950-1100</unitdate>
+			<unitdatestructured certainty="circa" unitdatetype="inclusive">
+				<daterange>
+					<fromdate notafter="0950" standarddate="0950">materials may slightly pre-date
+						0950</fromdate>
+					<todate notafter="1100" standarddate="1100">1100</todate>
+				</daterange>
+			</unitdatestructured>
+			<origination>
+				<persname encodinganalog="100" relator="creator" rules="wizlib">
+					<part>Slytherin</part>
+					<part>Salazar</part>
+					<part>d. circa 1100</part>
+				</persname>
+			</origination>
+			<physdesc>5 linear feet: 38 scrolls, 4 journals, 139 letters, 5 spell books</physdesc>
+			<physdescstructured coverage="whole" physdescstructuredtype="spaceoccupied">
+				<quantity>5</quantity>
+				<unittype>linear feet</unittype>
+			</physdescstructured>
+			<physdescset>
+				<physdescstructured coverage="part" physdescstructuredtype="materialtype">
+					<quantity approximate="false">38</quantity>
+					<unittype>scrolls</unittype>
+					<physfacet>Original scrolls are written in iron gall ink.</physfacet>
+					<dimensions localtype="width" unit="inches">18</dimensions>
+				</physdescstructured>
+				<physdescstructured coverage="part" physdescstructuredtype="materialtype">
+					<quantity approximate="false">4</quantity>
+					<unittype>journals</unittype>
+					<physfacet localtype="binding">Rough, amateur binding. Delicate.</physfacet>
+					<descriptivenote>
+						<p>Original journals appear to have been made by an amateur, possibly
+							Slytherin himself. The binding work is much rougher than on the spell
+							books and they must be handled with care.</p>
+					</descriptivenote>
+				</physdescstructured>
+				<physdescstructured coverage="part" physdescstructuredtype="materialtype">
+					<quantity approximate="false">139</quantity>
+					<unittype>letters</unittype>
+				</physdescstructured>
+				<physdescstructured coverage="part" physdescstructuredtype="materialtype">
+					<quantity approximate="false">5</quantity>
+					<unittype source="wizlib">spell books</unittype>
+					<physfacet localtype="binding">Original spell books are hand-stitched in common
+						leather with raised bands.</physfacet>
+				</physdescstructured>
+			</physdescset>
+			<physloc>Use copies of the materials are located in the Hogwarts Library reading room
+				vault. Originals are stored in a secure location.</physloc>
+			<repository>
+				<corpname normal="Hogwarts School of Witchcraft and Wizardry, Archives"
+					rules="wizlib"
+					source="http://harrypotter.wikia.com/wiki/Hogwarts_School_of_Witchcraft_and_Wizardry">
+					<part>Hogwarts School of Witchcraft and Wizardry</part>
+					<part>Archives</part>
+				</corpname>
+			</repository>
+		</did>
+		<accessrestrict>
+			<head>Restrictions on Access</head>
+			<p>Access to the materials is restricted to the following persons:</p>
+			<list listtype="deflist">
+				<listhead>
+					<head01>Category</head01>
+					<head02>Access level</head02>
+				</listhead>
+				<defitem>
+					<label>Students: Year 5 and above</label>
+					<item>With permission of a professor, students Year 5 and above may do
+						historical research on letters and journals included in the
+						collection.</item>
+				</defitem>
+				<defitem>
+					<label>Slytherin alumni</label>
+					<item>All materials, except spell books. Use of spell books requires approval
+						from the headmaster and archivist.</item>
+				</defitem>
+				<defitem>
+					<label>Hogwarts faculty and administration</label>
+					<item>All materials.</item>
+				</defitem>
+				<defitem>
+					<label>Researchers: Hogwarts alumni</label>
+					<item>Alumni of other Hogwarts houses must obtain approval from the archivist.
+						Use of spell books requires additional approval from the headmaster.</item>
+				</defitem>
+				<defitem>
+					<label>Researchers: Other</label>
+					<item>Researchers who graduated from other magical academies must obtain
+						permission from the Bloody Baron to use Salazar Slytherin's materials. They
+						must then obtain approval for their project's research topics from the
+						archivist. Use of spell books requires additional approval from the
+						headmaster.</item>
+				</defitem>
+			</list>
+		</accessrestrict>
+		<accruals>
+			<head>Accruals to the Collection</head>
+			<p>There are no accruals anticipated for this collection. However, materials are
+				occasionally donated by families with strong Slytherin ties.</p>
+		</accruals>
+		<acqinfo>
+			<head>Acquisition History</head>
+			<p>Correspondence with the Hogwarts founders and some teaching materials came to the
+				library directly after Salazar Slytherin's departure from Hogwarts. The acquisitoins
+				of other materials are addressed at their component level.</p>
+		</acqinfo>
+		<altformavail>
+			<head>Copies for Use</head>
+			<p>The materials have been carefully preserved, but researchers are encouraged to use
+				the copies which have been created over the past two hundred years unless their
+				research requires the originals. Use copies are available for all materials except
+				the spell books and will be used to fill research requests unless the originals are
+				specifically requested and the request is approved.</p>
+		</altformavail>
+		<appraisal>
+			<head>Appraisal of Materials</head>
+			<p>New items are appraised by comparison with Salazar Slytherin's handwriting, then the
+				materials are magically dated. All items determined to be authentic are added to the
+				collection. Donated materials connected to Slytherin (e.g. letters concerning
+				Slytherin, materials from his heirs, etc.) are assessed for their evidentiary value.
+				If they're considered sufficiently valuable, those materials will form their own
+				collection.</p>
+		</appraisal>
+		<arrangement>
+			<head>Arrangement of the Materials</head>
+			<p>Exact chronology of the materials cannot be established due to a lack of dates on any
+				items. Materials are arranged by type, then by deduced chronological order and/or
+				topic.</p>
+		</arrangement>
+		<bibliography>
+			<head>Works Citing the Collection</head>
+			<bibref>Bagshot, Bathilda. <title render="italic">
+					<part>Hogwarts: a History</part>
+				</title>.<date normal="1968">1968</date>, <ref
+					href="http://catalog.hogwarts.ac.uk/record=b11725882" show="new"
+					actuate="onrequest">Catalog record for <title>
+						<part>Hogwarts: a History</part>
+					</title></ref>.</bibref>
+			<bibref>Lestrange, Marius. <title>
+					<part>"An re-examination of Salazar Slytherin's role in English wizarding
+						marriages"</part>
+				</title>. Wizarding Studies Quarterly 51:3 (<date normal="2010-09">September
+					2010</date>): 384-443.</bibref>
+			<bibref>Malfoy, Elizabeth. <title render="italic">
+					<part>A biography of Salazar Slytherin</part>
+					<part>: England's greatest wizard</part>
+				</title><date normal="1843">1843</date>. <ref
+					href="http://catalog.hogwarts.ac.uk/record=b11727364" show="new"
+					actuate="onrequest">Catalog record for <title>
+						<part>A biography of Salazar Slytherin</part>
+						<part>: England's greatest wizard</part>
+					</title></ref>.</bibref>
+		</bibliography>
+		<bioghist>
+			<head>Biography of Salazar Slytherin</head>
+			<p>Salazar Slytherin was born in the first half of the tenth century, somewhere in
+				fen-country England. Researchers believe it was likely Norfolk, Lincolnshire, or
+				Cambridgeshire, but may have been a connected county. He came from a family of
+				pure-blood wizards, although the names of his parents are not recorded. It is
+				unknown whether he trained at a school of the time, at home, or under a master.
+				Together with Gryffindor, Ravenclaw, and Hufflepuff, he founded the <expan
+					abbr="HSWW">Hogwarts School of Witchcraft and Wizardry</expan>.</p>
+			<p>At Hogwarts, Slytherin taught Legilimency, the magical art of forming a mental
+				connection with another's mind and extracting information or interacting with their
+				thought processes. This may have been a genetic talent, as his descendent, Tom
+				Riddle, was also a noted legilimens. Slytherin was also a Parselmouth, a known genet
+				ic trait, and able to speak with snakes. He bred at least one basilisk, which he
+				left at Hogwarts in the Chamber of Secrets. The Chamber remained unopened until
+				1943, when Riddle opened it and used the basilisk to attack Muggle-borns. The
+				basilisk was not killed until 1993.</p>
+			<p>Slytherin believed that the school should only teach pure-blood students and should
+				definitely not accept students whose parents were both Muggles. His own house,
+				Slytherin, continued this tradition, but the other founders overruled him. After an
+				argument with Godric Gryffindor, which may have involved a duel, Slytherin left the
+				school.</p>
+			<p>While it is not known when or where Slytherin died, one of his spell books and a
+				final journal were recovered shortly before the turn of the twelfth century by
+				Slytherin alumnus and professor Albert Shallowheart. It is assumed that Slytherin
+				was dead when these books were recovered.</p>
+		</bioghist>
+		<controlaccess>
+			<persname encodinganalog="600" relator="creator" rules="wizlib"
+				source="http://harrypotter.wikia.com/wiki/Salazar_Slytherin">
+				<part localtype="surname">Slytherin</part>
+				<part localtype="forename">Salazar</part>
+				<part localtype="dates">d. circa 1100</part>
+			</persname>
+			<famname normal="Slytherin family" rules="wizlib"
+				source="http://harrypotter.wikia.com/wiki/Slytherin_family">
+				<part>Slytherin family</part>
+			</famname>
+			<corpname encodinganalog="610" normal="Hogwarts School of Witchcraft and Wizardry"
+				rules="wizlib"
+				source="http://harrypotter.wikia.com/wiki/Hogwarts_School_of_Witchcraft_and_Wizardry">
+				<part>Hogwarts School of Witchcraft and Wizardry</part>
+			</corpname>
+			<subject encodinganalog="650" normal="Magical History, 11th century" rules="wizlib">
+				<part>Magical History</part>
+				<part>11th century</part>
+			</subject>
+			<genreform encodinganalog="655" normal="Spell books" rules="wizlib">
+				<part>Spell books</part>
+			</genreform>
+			<genreform encodinganalog="655" normal="Diaries" rules="wizlib">
+				<part>Diaries</part>
+			</genreform>
+			<genreform encodinganalog="655" normal="Letters" rules="wizlib">
+				<part>Letters</part>
+			</genreform>
+			<geogname encodinganalog="651" rules="wizlib">
+				<part>Great Britain</part>
+				<part>11th century</part>
+			</geogname>
+			<occupation encodinganalog="656" rules="wizlib">
+				<part>Professor</part>
+				<part>Hogwarts School of Witchcraft and Wizardry</part>
+			</occupation>
+		</controlaccess>
+		<custodhist>
+			<head>Custodial History</head>
+			<p>Correspondence with the Hogwarts founders and some teaching materials came to the
+				library directly after Salazar Slytherin's departure from Hogwarts. The custodial
+				history of later acquisitions is listed in their component information.</p>
+		</custodhist>
+		<legalstatus>
+			<head>Legal Status of the Materials</head>
+			<p>In compliance with British Ministry of Magic Statute 38, regulating the distribution
+				of spell books, the Hogwarts reading room imposes special restrictions for the
+				access and use of spell books in the collection. Reproduction is entirely
+				prohibited. All other items fall under magical and muggle public domain laws.</p>
+		</legalstatus>
+		<otherfindaid>
+			<head>Other Finding Aid</head>
+			<p>An original description of this collection is available as a scroll in the Hogwarts
+				reading room. This finding aid is incomplete, but may be of use for researchers who
+				wish to view the contents list of the original collection.</p>
+		</otherfindaid>
+		<phystech>
+			<head>Physical Notes</head>
+			<p>Original scrolls and books have brittle edges, which restricts their use.</p>
+		</phystech>
+		<prefercite>
+			<head>Citation Guide</head>
+			<p>Please cite materials as follows:</p>
+			<p>Description or identification of item; date, if known; Manuscripts of Salazar
+				Slytherin (S.0001). Hogwarts School of Witchcraft and Wizardry Archives.</p>
+		</prefercite>
+		<processinfo>
+			<head>Processing Information</head>
+			<p>The original collection was accessioned and processed on an uncertain date, around
+					<date normal="1100" certainty="circa">1100 CE</date>. As archivists have added
+				to it over the centuries, each has added their own style to its arrangement and
+				description. Most recent processing and description was done by Winifred Pardol in
+				1992 when creating the first version of this finding aid.</p>
+		</processinfo>
+		<relatedmaterial>
+			<head>Related material</head>
+			<p>The Hogwarts Archives holds the materials of the school's other three founders. These
+				papers, particularly the letters, may prove useful in giving context to Slytherin's
+				writings.</p>
+			<archref>Series: <title>
+					<part>Manuscripts of the Founders of Hogwarts School of Witchcraft and
+						Wizardry</part>
+				</title>
+				<num>1</num>. <ref href="http://eadiva.com/hogwarts-ead/G.0001.xml" show="new"
+					actuate="onrequest">Manuscripts of Godric Gryffindor: Finding Aid</ref>
+			</archref>
+			<archref>Series: <title>
+					<part>Manuscripts of the Founders of Hogwarts School of Witchcraft and
+						Wizardry</part>
+				</title>
+				<num>2</num>. <ref href="http://eadiva.com/hogwarts-ead/H.0001.xml" show="new"
+					actuate="onrequest">Manuscripts of Helga Hufflepuff: Finding Aid</ref>
+			</archref>
+			<archref>Series: <title>
+					<part>Manuscripts of the Founders of Hogwarts School of Witchcraft and
+						Wizardry</part>
+				</title>
+				<num>3</num>. <ref href="http://eadiva.com/hogwarts-ead/R.0001.xml" show="new"
+					actuate="onrequest">Manuscripts of Rowena Ravenclaw: Finding Aid</ref>
+			</archref>
+		</relatedmaterial>
+		<relations>
+			<relation id="hhuf" relationtype="cpfrelation" actuate="onrequest" show="new"
+				href="http://eadiva.com/hogwarts-cpf/H.001.xml">
+				<relationentry>Hufflepuff, Helga</relationentry>
+				<descriptivenote>
+					<p>Co-founder of Hogwarts School of Witchcraft and Wizardry. While not the most
+						combative, her acceptance of all students willing to learn was the most at
+						odds with Slytherin's pure blood philosophy.</p>
+				</descriptivenote>
+			</relation>
+			<relation id="ggry" relationtype="cpfrelation" actuate="onrequest" show="new"
+				href="http://eadiva.com/hogwarts-cpf/G.001.xml">
+				<relationentry>Gryffindor, Godric</relationentry>
+				<descriptivenote>
+					<p>Co-founder of Hogwarts School of Witchcraft and Wizardry. Initially a good
+						friend and correspondent of Salazar Slytherin, Gryffindor later cut ties
+						over their disagreement concerning acceptance of muggle-born students.</p>
+				</descriptivenote>
+			</relation>
+			<relation id="rrav" relationtype="cpfrelation" actuate="onrequest" show="new"
+				href="http://eadiva.com/hogwarts-cpf/R.001.xml">
+				<relationentry>Ravenclaw, Rowena</relationentry>
+				<descriptivenote>
+					<p>Co-founder of Hogwarts School of Witchcraft and Wizardry.</p>
+				</descriptivenote>
+			</relation>
+		</relations>
+		<scopecontent>
+			<head>Scope and Content of the Collection</head>
+			<p>The collection is organized into four series:</p>
+			<p><emph render="bold">Series 1: Correspondence with Hogwarts Founders</emph> is
+				correspondence with the Hogwarts founders. It includes Slytherin's letters to Godric
+				Gryffindor, Helga Hufflepuff, and Rowena Ravenclaw. The collection consists
+				exclusively of Slytherin's letters to the founders, not their responses.</p>
+			<p><emph render="bold">Series 2: Other Correspondence</emph> is Slytherin's
+				correspondence with other witches and wizards. It includes letters received by
+				Slytherin and left at Hogwarts on his departure as well as some letters which were
+				donated later on by correspondents.</p>
+			<p><emph render="bold">Series 3: Class Notes</emph> consists of Slytherin's notes for
+				teaching classes on Legilimency, Charms, and Care of Magical Creatures.</p>
+			<p><emph render="bold">Series 4: Journals</emph> is made up of four journals kept by
+				Slytherin from around the time of Hogwarts' founding until shortly before his
+				death.</p>
+			<p><emph render="bold">Series 3: Spell Books</emph> consists of five spell books kept by
+				Slytherin to record jinxes, dark charms, legilimency, spells for the control of
+				basilisks, and the darkest arts.</p>
+		</scopecontent>
+		<separatedmaterial>
+			<head>Separated Material</head>
+			<p>During the <subject rules="wizlib"
+					source="http://harrypotter.wikia.com/wiki/First_Wizarding_War"
+					normal="Wizarding War, 1970-1981">
+					<part>First Wizarding War</part>
+					<part>1970-1981</part>
+				</subject>, a group of <corpname rules="wizlib"
+					source="http://harrypotter.wikia.com/wiki/Death_Eaters">
+					<part>Knights of Walpurgis</part>
+					<part>(Death Eaters)</part>
+				</corpname> stole Syltherin realia from its library display. Known items stolen were
+				Salazar Slytherin's signet ring, a painting (circa 1500) of Slytherin's ancestral
+				home, a ceremonial dagger belonging to Slytherin, and an enchanted 11th century
+				numismatic collection. Use copies of spell books in the archival collection were
+				also taken and had to be recreated. The original Slytherin papers were in the vault,
+				which had been protected by a Disillusionment Charm.</p>
+		</separatedmaterial>
+		<userestrict>
+			<head>Restrictions on Use of Materials</head>
+			<p>Restrictions on are predicated on the researcher already having passed the
+				restrictions on access.</p>
+			<!-- table frame="all" colsep="1" rowsep="1" -->
+			<table frame="all">
+				<tgroup align="center" cols="3">
+					<colspec colname="materialtype" colnum="1"/>
+					<colspec colname="usepermitted" colnum="2"/>
+					<colspec colname="permissionrequired" colnum="3"/>
+					<thead valign="middle">
+						<row>
+							<entry colname="materialtype">Material Type</entry>
+							<entry colname="usepermitted">Use Type</entry>
+							<entry colname="permissionrequired">Permission Required</entry>
+						</row>
+					</thead>
+					<tbody valign="middle">
+						<row>
+							<entry colname="materialtype">Journals</entry>
+							<entry colname="usepermitted">Personal notes</entry>
+							<entry colname="permissionrequired">none required</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Journals</entry>
+							<entry colname="usepermitted">Publication</entry>
+							<entry colname="permissionrequired">Archivist</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Letters</entry>
+							<entry colname="usepermitted">Personal notes</entry>
+							<entry colname="permissionrequired">none required</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Letters</entry>
+							<entry colname="usepermitted">Publication</entry>
+							<entry colname="permissionrequired">Archivist</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Class notes</entry>
+							<entry colname="usepermitted">Personal notes</entry>
+							<entry colname="permissionrequired">Archivist</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Class notes</entry>
+							<entry colname="usepermitted">Publication</entry>
+							<entry colname="permissionrequired">Archivist and Headmaster</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Spell books</entry>
+							<entry colname="usepermitted">Personal notes</entry>
+							<entry colname="permissionrequired">Archivist and Headmaster</entry>
+						</row>
+						<row>
+							<entry colname="materialtype">Spell books</entry>
+							<entry colname="usepermitted">Publication</entry>
+							<entry colname="permissionrequired">Not permitted</entry>
+						</row>
+					</tbody>
+				</tgroup>
+			</table>
+		</userestrict>
+		<dsc>
+			<c level="series">
+				<did>
+					<unittitle>Correspondence with Hogwarts Founders</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0975">975</fromdate>
+							<todate notafter="1050">1050</todate>
+						</daterange>
+					</unitdatestructured>
+					<container containerid="SL0001.01" localtype="box">1</container>
+					<!-- commenting out to make valid 
+						bug in current version of the schema: containerid not of type ID					
+						<container parent="SL0001.01" localtype="folders">1-11</container> -->
+					<container localtype="folders">1-11</container>
+
+					<physdesc>84 letters</physdesc>
+				</did>
+				<controlaccess>
+					<genreform encodinganalog="655" rules="wizlib">
+						<part>Letters</part>
+					</genreform>
+					<persname encodinganalog="600" normal="Gryffindor, Godric" rules="wizlib"
+						source="http://eadiva.com/hogwarts-cpf/G.001.xml">
+						<part>Godric Gryffindor</part>
+					</persname>
+					<persname encodinganalog="600" normal="Hufflepuff, Helga" rules="wizlib"
+						source="http://eadiva.com/hogwarts-cpf/H.001.xml">
+						<part>Helga Hufflepuff</part>
+					</persname>
+					<persname encodinganalog="600" normal="Ravenclaw, Rowena" rules="wizlib"
+						source="http://eadiva.com/hogwarts-cpf/R.001.xml">
+						<part>Rowena Ravenclaw</part>
+					</persname>
+				</controlaccess>
+				<arrangement>
+					<head>Arrangement</head>
+					<p>Letters are arranged alphabetically by recipient's last name.</p>
+				</arrangement>
+				<scopecontent>
+					<head>Scope and Contents</head>
+					<p>The letters consist of correspondence with Slytherin's fellow founders of
+						Hogwarts. They cover topics from administrative matters to plans for
+						developing the curriculum to discussion of their respective families. The
+						letters appear to begin around the time of the founding of Hogwarts and
+						continue until Slytherin's departure.</p>
+				</scopecontent>
+				<index>
+					<head>Index of Correspondents</head>
+					<indexentry>
+						<persname normal="Gryffindor, Godric" rules="wizlib"
+							source="hhttp://eadiva.com/hogwarts-cpf/G.001.xml">
+							<part>Godric Gryffindor</part>
+						</persname>
+						<ptrgrp>
+							<ref show="new" actuate="onrequest"
+								href="http://eadiva.com/hogwarts-cpf/G.001.xml">Biographical and
+								Relational Information</ref>
+							<ptr target="ggry" show="replace" actuate="onrequest"
+								linktitle="Relationship to Salazar Slytherin"/>
+						</ptrgrp>
+					</indexentry>
+					<indexentry>
+						<persname normal="Hufflepuff, Helga" rules="wizlib"
+							source="http://eadiva.com/hogwarts-cpf/H.001.xml">
+							<part>Helga Hufflepuff</part>
+						</persname>
+						<ptrgrp>
+							<ref show="new" actuate="onrequest"
+								href="http://eadiva.com/hogwarts-cpf/H.001.xml">Biographical and
+								Relational Information</ref>
+							<ptr target="hhuf" show="replace" actuate="onrequest"
+								linktitle="Relationship to Salazar Slytherin"/>
+						</ptrgrp>
+					</indexentry>
+					<indexentry>
+						<persname normal="Ravenclaw, Rowena" rules="wizlib"
+							source="http://eadiva.com/hogwarts-cpf/G.001.xml">
+							<part>Rowena Ravenclaw</part>
+						</persname>
+						<ptrgrp>
+							<ref show="new" actuate="onrequest"
+								href="http://eadiva.com/hogwarts-cpf/R.001.xml">Biographical and
+								Relational Information</ref>
+							<ptr target="rrav" show="replace" actuate="onrequest"
+								linktitle="Relationship to Salazar Slytherin"/>
+						</ptrgrp>
+					</indexentry>
+				</index>
+				<acqinfo>
+					<head>Acquisitions Information</head>
+					<p>These letters were donated by the three remaining Hogwarts founders shortly
+						after Slytherin left the school. Their letters to him can be found in their
+						respective collections.</p>
+				</acqinfo>
+				<otherfindaid>
+					<head>Other Finding Aid</head>
+					<p>In 1965, as part of her research for <title render="italic">
+							<part>Hogwarts: A History</part>
+						</title>, Bathilda Bagshot created an index of letters between Hogwarts
+						founders based on subject and occasional date information. Each entry
+						contains a brief summary of the letter's context and contents. A copy of
+						this index is available for researchers. It was also used to create <ref
+							href="http://catalog.hogwarts.ac.uk/record=b11713487" show="new"
+							actuate="onrequest"><title render="italic">
+								<part>Correspondence of the Hogwarts Founders</part>
+							</title></ref>, see <ptr target="ah876"
+							linktitle="Alternate Form Available" show="replace" actuate="onrequest"
+						/> for further details.</p>
+				</otherfindaid>
+				<altformavail id="ah876">
+					<head>Alternate Form Available</head>
+					<p>In 1972, Balthilda Bagshot published <title render="italic">
+							<part>Correspondence of the Hogwarts Founders</part>
+						</title>, full transcriptions of the letters between Salazar Slytherin,
+						Godric Gryffindor, Helga Hufflepuff, and Rowena Ravenclaw. This book may
+						prove more helpful to researchers than reading Slytherin's letters alone. It
+						is available in the <ref
+							href="http://catalog.hogwarts.ac.uk/record=b11713487" show="new"
+							actuate="onrequest">main Hogwarts library</ref>.</p>
+				</altformavail>
+			</c>
+			<c level="series">
+				<did>
+					<unittitle>Other Correspondence</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0975">975</fromdate>
+							<todate notafter="1050">1050</todate>
+						</daterange>
+					</unitdatestructured>
+					<container containerid="SL0001.02" localtype="box">2</container>
+					<container localtype="folders">12-18</container>
+					<!-- commenting out to make valid 
+						bug in current version of the schema: containerid not of type ID
+					<container parent="SL0001.02" localtype="folders">12-18</container>
+					-->
+					<physdesc>55 letters</physdesc>
+				</did>
+				<controlaccess>
+					<genreform encodinganalog="655" rules="wizlib">
+						<part>Letters</part>
+					</genreform>
+				</controlaccess>
+				<arrangement>
+					<head>Arrangement</head>
+					<p>Letters are arranged alphabetically by correspondent's last name.</p>
+				</arrangement>
+				<scopecontent>
+					<head>Scope and Content</head>
+					<p>All correspondence with people other than Hogwarts founders. May contain
+						letters both two and from Slytherin.</p>
+					<list listtype="deflist">
+						<listhead>
+							<head01>Correspondent</head01>
+							<head02>Description/Relationship</head02>
+						</listhead>
+						<defitem>
+							<label>Lavinia Black</label>
+							<item>Hogwarts professor of runes</item>
+						</defitem>
+						<defitem>
+							<label>Belle Jouliet</label>
+							<item>French witch</item>
+						</defitem>
+						<defitem>
+							<label>Marcus Malfoy</label>
+							<item>Hogwarts professor of Ghoul Studies</item>
+						</defitem>
+						<defitem>
+							<label>Phineas Peverell</label>
+							<item>Hogwarts professor of potions</item>
+						</defitem>
+						<defitem>
+							<label>Morgul Scadamer</label>
+							<item>Wizard and childhood friend</item>
+						</defitem>
+					</list>
+				</scopecontent>
+			</c>
+			<c level="series">
+				<did>
+					<unittitle>Class Notes</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0975">975</fromdate>
+							<todate notafter="1050">1050</todate>
+						</daterange>
+					</unitdatestructured>
+					<physdesc>38 scrolls</physdesc>
+					<container localtype="scrollboxes">1-38</container>
+					<didnote>The archives currently holds scrolls with class notes for Slytherin's
+						classes on legilimency, charms, and care of magical creatures. Tradition
+						holds that he taught a class on alchemy as well.</didnote>
+				</did>
+				<scopecontent>
+					<head>Scope and Content</head>
+					<p>This series consists of scrolls on which Slytherin recorded notes for the
+						teaching legilimency, charms, and care of magical creatures. Notes include
+						references to many books which no longer exist, lists of class topics, and
+						detailed notes on the subjects. Many researchers find these useful for
+						deriving an impression of Slytherin's teaching philosophy and
+						priorities.</p>
+				</scopecontent>
+				<c level="file">
+					<did>
+						<unittitle>Class Notes for Legilimency</unittitle>
+						<physdesc>22 scrolls</physdesc>
+						<container localtype="scrollboxes">1-22</container>
+					</did>
+					<controlaccess>
+						<function encodinganalog="657" rules="wizlib">
+							<part>Magical instruction</part>
+						</function>
+						<genreform encodinganalog="655" rules="wizlib">
+							<part>Teaching materials</part>
+						</genreform>
+						<subject encodinganalog="650" rules="wizlib">
+							<part>Legilimency</part>
+						</subject>
+						<subject encodinganalog="650" rules="wizlib">
+							<part>Restricted magic</part>
+						</subject>
+					</controlaccess>
+					<scopecontent>
+						<head>Scope and Content</head>
+						<p>Slytherin taught extensively on legilimency, over the qualms and informal
+							objections of other houses' founders. These 22 scrolls include class
+							outlines, spell types, instructions for legilimentic dueling, and other
+							materials related to legimency.</p>
+					</scopecontent>
+					<accessrestrict>
+						<head>Restrictions on Access</head>
+						<p>Beyond restrictions to the use of the Class Notes series, the archivist
+							reserves the right to restrict access to this material, as it comes
+							dangerously close to the Dark Arts.</p>
+					</accessrestrict>
+				</c>
+				<c level="file">
+					<did>
+						<unittitle>Class Notes for Charms</unittitle>
+						<physdesc>9 scrolls</physdesc>
+						<container localtype="scrollboxes">23-31</container>
+					</did>
+					<controlaccess>
+						<function encodinganalog="657" rules="wizlib">
+							<part>Magical instruction</part>
+						</function>
+						<genreform encodinganalog="655" rules="wizlib">
+							<part>Teaching materials</part>
+						</genreform>
+						<subject encodinganalog="650" rules="wizlib">
+							<part>Charms</part>
+						</subject>
+					</controlaccess>
+					<scopecontent>
+						<head>Scope and Content</head>
+						<p>These scrolls contain Slytherin's notes for teaching the following
+							charms: <foreign lang="spl" render="italic">Alohomora</foreign>,
+								<foreign lang="spl" render="italic">anti-Alohomora</foreign>,
+								<foreign lang="spl" render="italic">Bombarda</foreign>, <foreign
+								lang="spl" render="italic">Deprimo</foreign>, <foreign lang="spl"
+								render="italic">Dessendium</foreign>, <foreign lang="spl"
+								render="italic">Epoximise</foreign>, <foreign lang="spl"
+								render="italic">Glacius</foreign> (all three forms), <foreign
+								lang="spl" render="italic">Impervius</foreign>, <foreign lang="spl"
+								render="italic">Lacarnum Inflamarae</foreign>, <foreign lang="spl"
+								render="italic">Portaberto</foreign>, <foreign lang="spl"
+								render="italic">Protego</foreign> (multiple forms), <foreign
+								lang="spl" render="italic">Stupefy</foreign> (multiple forms),
+								<foreign lang="spl" render="italic">Verdimillious</foreign>,
+								<foreign lang="spl" render="italic">Waddiwasi</foreign>.</p>
+					</scopecontent>
+					<fileplan>
+						<head>Scroll Contents</head>
+						<p>The charms may be found on the following scrolls:</p>
+						<list listtype="deflist">
+							<defitem>
+								<label>Scroll 1</label>
+								<item><foreign lang="spl" render="italic">Alohomora</foreign>,
+										<foreign lang="spl" render="italic"
+									>anti-Alohomora</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 2</label>
+								<item><foreign lang="spl" render="italic">Bombarda</foreign>,
+										<foreign lang="spl" render="italic">Deprimo</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 3</label>
+								<item><foreign lang="spl" render="italic">Epoximise</foreign>,
+										<foreign lang="spl" render="italic">Glacius</foreign> (all
+									three forms) </item>
+							</defitem>
+							<defitem>
+								<label>Scroll 4</label>
+								<item><foreign lang="spl" render="italic">Stupefy</foreign>
+									(multiple forms)</item>
+							</defitem>
+							<defitem>
+								<label>Scroll 5</label>
+								<item><foreign lang="spl" render="italic">Impervius</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 6</label>
+								<item><foreign lang="spl" render="italic">Lacarnum
+										Inflamarae</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 7</label>
+								<item><foreign lang="spl" render="italic">Dissendium</foreign>,
+										<foreign lang="spl" render="italic"
+									>Portaberto</foreign></item>
+							</defitem>
+							<defitem>
+								<label>Scroll 8</label>
+								<item><foreign lang="spl" render="italic">Protego</foreign>
+									(multiple forms)</item>
+							</defitem>
+							<defitem>
+								<label>Scroll 9</label>
+								<item><foreign lang="spl" render="italic">Verdimillious</foreign>,
+										<foreign lang="spl" render="italic"
+									>Waddiwasi</foreign></item>
+							</defitem>
+						</list>
+						<p>Scrolls are not originally numbered. They are ordered based on their
+							aprpoximate alphabetical order.</p>
+					</fileplan>
+				</c>
+				<c level="file">
+					<did>
+						<unittitle>Class Notes for Care of Magical Creatures</unittitle>
+						<physdesc>7 scrolls</physdesc>
+						<container localtype="scrollboxes">32-38</container>
+						<daoset coverage="part">
+							<dao daotype="derived"
+								href="http://eadiva.com/wizlib-files/salamanders.jpg"
+								localtype="portion" show="embed">
+								<descriptivenote>
+									<p>Sample portion of a scroll on the care of salamanders</p>
+								</descriptivenote>
+							</dao>
+							<dao daotype="derived" href="http://eadiva.com/wizlib-files/imps.jpg"
+								localtype="portion" show="embed">
+								<descriptivenote>
+									<p>Sample portion of a scroll on the care of Imps.</p>
+								</descriptivenote>
+							</dao>
+							<descriptivenote>
+								<p>These materials were digitized for the use of professors teaching
+									Care of Magical Creatures. These images are examples of
+									digitized files which may be available to researchers with the
+									archivists' permission. To request a copy, please contact the
+									archivist.</p>
+							</descriptivenote>
+						</daoset>
+					</did>
+					<controlaccess>
+						<function encodinganalog="657" rules="wizlib">
+							<part>Magical instruction</part>
+						</function>
+						<genreform encodinganalog="655" rules="wizlib">
+							<part>Teaching materials</part>
+						</genreform>
+						<subject encodinganalog="650" rules="wizlib">
+							<part>Care of magical creatures</part>
+						</subject>
+					</controlaccess>
+					<index>
+						<head>Index of Animals Described</head>
+						<p>Animals are grouped by class and paired with a link to the official
+							Ministry of Magic magical creature class description.</p>
+						<indexentry>
+							<namegrp>
+								<name>
+									<part>Imp</part>
+								</name>
+								<name>
+									<part>Salamander</part>
+								</name>
+							</namegrp>
+							<ref
+								href="http://regcontrol.ministry.magic.uk/magical-creature-tables/class_1"
+								show="new" actuate="onrequest">Table of Class 1 Creatures</ref>
+						</indexentry>
+						<indexentry>
+							<namegrp>
+								<name>
+									<part>Cockatrice</part>
+								</name>
+								<name>
+									<part>Griffin</part>
+								</name>
+								<name>
+									<part>Thestral</part>
+								</name>
+							</namegrp>
+							<ref
+								href="http://regcontrol.ministry.magic.uk/magical-creature-tables/class_2"
+								show="new" actuate="onrequest">Table of Class 2 Creatures</ref>
+						</indexentry>
+						<indexentry>
+							<name>
+								<part>Basilisk</part>
+							</name>
+							<ref
+								href="http://regcontrol.ministry.magic.uk/magical-creature-tables/class_3"
+								show="new" actuate="onrequest">Table of Class 3 Creatures</ref>
+						</indexentry>
+					</index>
+					<scopecontent>
+						<head>Scope and Content</head>
+						<p>Each scroll contains information on a different type of magical creature.
+							The scrolls include lecture notes, lists of references, and notes about
+							the health and disposition of animals being held for student use.</p>
+					</scopecontent>
+					<altformavail>
+						<head>Alternate Form Available</head>
+						<p>These materials have been digitized for the use of professors teaching
+							Care of Magical Creatures.</p>
+					</altformavail>
+					<odd>
+						<head>Other Information</head>
+						<p>Many researchers are unaware of Slytherin's time as a teacher of the Care
+							of Magical Creatures class. His notes demonstrate a strong affinity with
+							the darker magical creatures and certain letters between Slytherin and
+							Helga Hufflepuff call into question his methods of binding particular
+							creatures to his will.</p>
+					</odd>
+				</c>
+			</c>
+			<c level="series">
+				<did>
+					<unittitle>Journals</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0950">950</fromdate>
+							<todate notafter="1050">1050</todate>
+						</daterange>
+					</unitdatestructured>
+					<physdesc>4 journals</physdesc>
+					<container containerid="SL0001.03" localtype="box">3</container>
+					<abstract> The following are sample passages from Slytherin's journals:<lb/>
+						<quote>Refining <foreign lang="spl" render="italic">Legilimency</foreign>. I
+							believe I have discovered the secret of doing more than parsing thought.
+							I may now twist memories to create visions.</quote>
+						<lb/>
+						<quote>A quarrel today between my students and those mudbloods allowed in by
+							Hufflepuff. It may become necessary to withhold the teaching of <foreign
+								lang="spl" render="italic">Crucio</foreign> until the final year of
+							studies. Hufflepuff has suggested that the matter should be brought
+							before the Wizards' Council and wants to expel young Lucian. I will talk
+							to Godric about instituting an internal court for trials concerning
+							student matters. Expulsion should be a matter of last resort, for if we
+							do not train these bright young talents, they may be vulnerable to
+							Muggle courts and burning.</quote>
+					</abstract>
+				</did>
+				<controlaccess>
+					<genreform encodinganalog="655" rules="wizlib">
+						<part>Journals</part>
+					</genreform>
+				</controlaccess>
+				<scopecontent>
+					<head>Scope and Content</head>
+					<p>The journals are sequential, each covering mundane activities of Slytherin's
+						life. Some days simply record classes or meetings, others have notes with
+						his opinions and thoughts on particular topics. The journals contain <emph
+							render="bolditalic">no</emph> magical content (spells, potion recipes,
+						etc.), although all four include his opinions concerning the use and
+						teaching of magic. The journals begin just before the founding of Hogwarts
+						and continue until shortly past his departure. He appears to have used them
+						primarily to express opinions and to record information for future
+						reference. The final journal was found in a small residence near <geogname>
+							<part>Slackbuie</part>
+							<part>Scotland</part>
+							<geographiccoordinates coordinatesystem="UTM">30V 427400mE
+								6368503mN</geographiccoordinates>
+						</geogname> by professor Albert Shallowheart along with his spell book on
+						jinxes. It only contained 5 entries subsequent to his departure from
+						Hogwarts, none of which gave details about his locations after leaving
+						Hogwarts. <footnote>
+							<p>Over the centuries, many Slytherin faithful have combed the Slackbuie
+								area looking for signs of his presence there. However, if any
+								information has been found, it has not been published or passed down
+								through common lore.</p>
+						</footnote></p>
+				</scopecontent>
+			</c>
+			<c level="series">
+				<did>
+					<unittitle>Spell Books</unittitle>
+					<unitdatestructured unitdatetype="inclusive">
+						<daterange>
+							<fromdate notafter="0950">950</fromdate>
+							<todate notafter="1100">1100</todate>
+						</daterange>
+					</unitdatestructured>
+					<physdesc>5 spell books</physdesc>
+					<container localtype="boxes">4-5</container>
+					<materialspec>Many spells are encoded in the arcanumscript commonly used by
+						wizards of the time to prevent the information from falling into Muggle
+						hands. A <ref href="http://catalog.hogwarts.ac.uk/record=b11716545"
+							show="new" actuate="onrequest">reference guide to arcanumscript</ref> is
+						available in the Restricted Section of the main Hogwarts library. Please ask
+						the archivist for assistance in finding it.</materialspec>
+					<langmaterial>
+						<languageset>
+							<language langcode="lat">Latin</language>
+							<script scriptcode="zzzz">arcanumscript</script>
+						</languageset>
+					</langmaterial>
+				</did>
+				<scopecontent>
+					<head>List of spell books</head>
+					<list listtype="ordered">
+						<item>Jinxes</item>
+						<item>Dark charms</item>
+						<item>Legilimency</item>
+						<item>Control of basilisks</item>
+						<item>Truest curses</item>
+					</list>
+				</scopecontent>
+				<controlaccess>
+					<genreform encodinganalog="655" rules="wizlib">
+						<part>Spell books</part>
+					</genreform>
+				</controlaccess>
+				<originalsloc audience="internal">
+					<p>All original spell books are stored in the headmaster's office, separately
+						from other original archival materials.</p>
+				</originalsloc>
+				<altformavail>
+					<head>Use Copies Available</head>
+					<p>Original spell books have not been fully reproduced for researcher use.
+						Reproduction of these materials was supervised by Aurors from the <abbr
+							expan="Ministry of Magic">M.o.M</abbr>, who determined that the mere
+						transcription of certain spells might prove dangerous. Researchers wishing
+						to consult the spell books in their entireties must first obtain permission
+						to use original materials from Hogwarts staff, then obtain secondary
+						permission from the Aurors Office to proceed.</p>
+				</altformavail>
+				<acqinfo>
+					<head>Acquisitions Information</head>
+					<chronlist>
+						<chronitem>
+							<datesingle notbefore="1100">circa 1100</datesingle>
+							<chronitemset>
+
+								<event>Slytherin's spell book of jinxes was found by professor <name>
+										<part>Albert Shallowheart</part>
+									</name> in an abandoned residence near <geogname>
+										<part>Slackbuie</part>
+										<part>Scotland</part>
+									</geogname>. He initially intended it for the possession of
+									Slytherin house. However the headmaster confiscated, who added
+									it to Slytherin's materials in the library.</event>
+							</chronitemset>
+						</chronitem>
+
+						<chronitem>
+							<datesingle notbefore="1290">circa 1300</datesingle>
+							<event><persname normal="Peverell, Lucinda" rules="wizlib"
+									relator="donor">
+									<part>Lucinda Peverell</part>
+								</persname>, daughter of <persname rules="wizlib"
+									source="http://harrypotter.wikia.com/wiki/Cadmus_Peverell">
+									<part>Cadamus Peverell</part>
+								</persname>, donated a spell book of dark charms which had been
+								given to her father by Slytherin at some point after his departure
+								from Hogwarts. Her letter accompanying the book noted that it was
+								"prone to muttering" and the headmaster at the time took appropriate
+								steps to shield it.</event>
+						</chronitem>
+						<chronitem>
+							<datesingle notafter="1820">before 1820</datesingle>
+							<event><persname normal="Gaunt, Malachi" rules="wizlib" relator="donor">
+									<part>Malachi Gaunt</part>
+								</persname>, one of the few members of that family to be sorted into
+								Ravenclaw, donated two of Slytherin's spell books, one devoted to
+								legilimency, and one concerning spells to control basilisks and
+								other serpents.</event>
+						</chronitem>
+
+						<chronitem>
+							<dateset>
+								<datesingle standarddate="1924-03">March 1924</datesingle>
+								<daterange>
+									<fromdate standarddate="1924-07">July 1924</fromdate>
+									<todate standarddate="1924-09">September 1924</todate>
+								</daterange>
+							</dateset>
+							<chronitemset>
+
+								<event>When <persname normal="Gaunt, Morfin" rules="wizlib"
+										source="http://harrypotter.wikia.com/wiki/Morfin_Gaunt">
+										<part>Morfin Gaunt</part>
+									</persname> was sentenced to three years in <corpname
+										normal="Azkaban Prison" rules="wizlib"
+										source="http://harrypotter.wikia.com/wiki/Azkaban">
+										<part>Azkaban</part>
+									</corpname>, a spell book of extremely dangerous dark arts was
+									discovered among the belongings he attempted to bring with him.
+									Aurors determined the spell book's creator to be Salazar
+									Slytherin. The book was donated to Hogwarts for exclusive use of
+									headmasters and Defense Against the Dark Arts professors. The
+									spell book has multiple charms intended to alert aurors to
+									unauthorized uses.</event>
+								<event>For nearly three months in 1924, the spell book was
+									temporarily removed from Hogwarts to the Ministry of Magic after
+										<persname normal="Gaunt, Marvolo" rules="wizlib"
+										source="http://harrypotter.wikia.com/wiki/Marvolo_Gaunt">
+										<part>Marvolo Gaunt</part>
+									</persname> launched an unsuccessful appeal for its return to
+									the family as inherited property. The spell book was returned to
+									Hogwarts afterward.</event>
+							</chronitemset>
+						</chronitem>
+
+					</chronlist>
+				</acqinfo>
+				<custodhist>
+					<head>Custodial History</head>
+					<p>Based on the pattern of acquisition, Slytherin's spell books have been passed
+						down through the Peverell and Gaunt families. It seems likely that Slytherin
+						visisted one of more of his children and close friends after his departure
+						from Hogwarts and left his spell books in their charge. By the point of his
+						death, it seems unlikely that he would have had need for consulting
+						reference materials as he was a highly-accomplished wizard. Early archivists
+						speculate that he retained his book of jinxes in order to record new spells
+						and was not able to transmit it to its designated party before his
+						death.</p>
+				</custodhist>
+				<odd>
+					<head>Other Information</head>
+					<p>The archivist cannot provide information on the secret location of the
+						original spell books or the types of spells and charms used to protect them
+						from unauthorized research. Researchers are advised not to waste their time
+						and the archivists' with repeated inquiries.</p>
+				</odd>
+			</c>
+		</dsc>
+	</archdesc>
+</ead>

--- a/tests/test_eadator.py
+++ b/tests/test_eadator.py
@@ -17,11 +17,13 @@ class TestEadator(unittest.TestCase):
                             type=argparse.FileType('r'))
         parser.add_argument('--dtd', default="%s/ents/ead.dtd" % lib_folder, required=False, )
         parser.add_argument('--xsd', default="%s/ents/ead.xsd" % lib_folder, required=False, )
+        parser.add_argument('--rng', default="%s/ents/ead3.rng" % lib_folder, required=False, )
         parser.add_argument('--count', action='store_true' )
 
         # test valid instances
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'test-dtd-valid.xml')]))
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'test-xsd-valid.xml')]))
+        eadator.main(parser.parse_args([os.path.join(cmd_folder,'S.0001_valid.xml')]))
 
         message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-dtd-valid.xml'))
         self.assertTrue(valid)
@@ -31,15 +33,24 @@ class TestEadator(unittest.TestCase):
         self.assertTrue(valid)
         self.assertEqual(0,error_count)
 
+        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'S.0001_valid.xml'))
+        self.assertTrue(valid)
+        self.assertEqual(0,error_count)
+
         # test invalid instances
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'test-dtd-invalid.xml')]))
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'test-dtd-invalid.xml')]))
+        self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'S.0001_invalid.xml')]))
 
         message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-dtd-invalid.xml'))
         self.assertFalse(valid)
         self.assertEqual(1,error_count)
 
         message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-xsd-invalid.xml'))
+        self.assertFalse(valid)
+        self.assertEqual(1,error_count)
+
+        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'S.0001_invalid.xml'))
         self.assertFalse(valid)
         self.assertEqual(1,error_count)
 

--- a/tests/test_eadator.py
+++ b/tests/test_eadator.py
@@ -25,34 +25,28 @@ class TestEadator(unittest.TestCase):
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'test-xsd-valid.xml')]))
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'S.0001_valid.xml')]))
 
-        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'test-dtd-valid.xml'))
-        self.assertTrue(valid)
-        self.assertEqual(0,error_count)
+        res = eadator.validate(os.path.join(cmd_folder,'test-dtd-valid.xml'))
+        self.assertEqual(0,res.error_count)
 
-        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'test-xsd-valid.xml'))
-        self.assertTrue(valid)
-        self.assertEqual(0,error_count)
+        res = eadator.validate(os.path.join(cmd_folder,'test-xsd-valid.xml'))
+        self.assertEqual(0,res.error_count)
 
-        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'S.0001_valid.xml'))
-        self.assertTrue(valid)
-        self.assertEqual(0,error_count)
+        res = eadator.validate(os.path.join(cmd_folder,'S.0001_valid.xml'))
+        self.assertEqual(0,res.error_count)
 
         # test invalid instances
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'test-dtd-invalid.xml')]))
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'test-dtd-invalid.xml')]))
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'S.0001_invalid.xml')]))
 
-        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'test-dtd-invalid.xml'))
-        self.assertFalse(valid)
-        self.assertEqual(1,error_count)
+        res = eadator.validate(os.path.join(cmd_folder,'test-dtd-invalid.xml'))
+        self.assertEqual(1,res.error_count)
 
-        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'test-xsd-invalid.xml'))
-        self.assertFalse(valid)
-        self.assertEqual(1,error_count)
+        res = eadator.validate(os.path.join(cmd_folder,'test-xsd-invalid.xml'))
+        self.assertEqual(1,res.error_count)
 
-        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'S.0001_invalid.xml'))
-        self.assertFalse(valid)
-        self.assertEqual(1,error_count)
+        res = eadator.validate(os.path.join(cmd_folder,'S.0001_invalid.xml'))
+        self.assertEqual(1,res.error_count)
 
 
 if __name__ == '__main__':

--- a/tests/test_eadator.py
+++ b/tests/test_eadator.py
@@ -18,22 +18,22 @@ class TestEadator(unittest.TestCase):
         parser.add_argument('--dtd', default="%s/ents/ead.dtd" % lib_folder, required=False, )
         parser.add_argument('--xsd', default="%s/ents/ead.xsd" % lib_folder, required=False, )
         parser.add_argument('--rng', default="%s/ents/ead3.rng" % lib_folder, required=False, )
-        parser.add_argument('--count', action='store_true' )
+        parser.add_argument('--verbose', action='store_true' )
 
         # test valid instances
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'test-dtd-valid.xml')]))
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'test-xsd-valid.xml')]))
         eadator.main(parser.parse_args([os.path.join(cmd_folder,'S.0001_valid.xml')]))
 
-        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-dtd-valid.xml'))
+        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'test-dtd-valid.xml'))
         self.assertTrue(valid)
         self.assertEqual(0,error_count)
 
-        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-xsd-valid.xml'))
+        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'test-xsd-valid.xml'))
         self.assertTrue(valid)
         self.assertEqual(0,error_count)
 
-        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'S.0001_valid.xml'))
+        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'S.0001_valid.xml'))
         self.assertTrue(valid)
         self.assertEqual(0,error_count)
 
@@ -42,15 +42,15 @@ class TestEadator(unittest.TestCase):
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'test-dtd-invalid.xml')]))
         self.assertRaises(SystemExit, eadator.main, parser.parse_args([os.path.join(cmd_folder,'S.0001_invalid.xml')]))
 
-        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-dtd-invalid.xml'))
+        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'test-dtd-invalid.xml'))
         self.assertFalse(valid)
         self.assertEqual(1,error_count)
 
-        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'test-xsd-invalid.xml'))
+        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'test-xsd-invalid.xml'))
         self.assertFalse(valid)
         self.assertEqual(1,error_count)
 
-        message, valid, error_count = eadator.validate(os.path.join(cmd_folder,'S.0001_invalid.xml'))
+        message, valid, error_count, ead_type = eadator.validate(os.path.join(cmd_folder,'S.0001_invalid.xml'))
         self.assertFalse(valid)
         self.assertEqual(1,error_count)
 
@@ -58,7 +58,7 @@ class TestEadator(unittest.TestCase):
 if __name__ == '__main__':
     unittest.main()
 
-# Copyright © 2013, Regents of the University of California
+# Copyright © 2015, Regents of the University of California
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
- Add EAD 3.0 support (develop branch; from around 2015 Jan.
- changes the `--count` flag to `--verbose` and adds the type of schema to the report
- change `validate()` to return a named tuple of the validation results

Closes #3 
